### PR TITLE
feat(camera): 가이드 펜툴 스트로크 사진·라이브포토 저장 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@
 - Actor 격리와 `@MainActor` 적용 판단 가이드 추가
 - Swift Modern Concurrency 우선 사용 가이드 추가
 - 로깅과 공통 유틸 사용 가이드 추가
+- 펜 가이드를 사진 저장 결과에 함께 합성하는 설정과 저장 기능 추가
 
 ### Changed
 
 - 에이전트 작업 정책을 토픽별 문서로 분리
+- 펜 stroke 상태를 `GuidingStrokeRepository` 단일 출처로 재구성
 
 ### Deprecated
 

--- a/QueenCam/QueenCam/Common/Dependencies/DenpencyContainer.swift
+++ b/QueenCam/QueenCam/Common/Dependencies/DenpencyContainer.swift
@@ -16,6 +16,9 @@ final class DependencyContainer {
     networkManager: networkManager,
     connectionManager: connectionManager
   )
+  lazy var guidingStrokeRepository: GuidingStrokeRepositoryProtocol = GuidingStrokeRepository(
+    networkService: networkService
+  )
 
   lazy var previewCaptureService = PreviewCaptureService()
 

--- a/QueenCam/QueenCam/Presentation/Localization/Localizable.xcstrings
+++ b/QueenCam/QueenCam/Presentation/Localization/Localizable.xcstrings
@@ -918,6 +918,16 @@
         }
       }
     },
+    "펜 가이드 함께 저장" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save with pen guide"
+          }
+        }
+      }
+    },
     "취소" : {
       "localizations" : {
         "en" : {

--- a/QueenCam/QueenCam/Presentation/ViewModels/Camera/CameraDelegate.swift
+++ b/QueenCam/QueenCam/Presentation/ViewModels/Camera/CameraDelegate.swift
@@ -7,7 +7,8 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
   private let logger = QueenLogger(category: "CameraDelegate")
   private let isCameraPosition: AVCaptureDevice.Position
 
-  private let completion: ((PhotoOuput?) -> Void)
+  private let photoOutputProcessor: ((PhotoOuput) -> PhotoOuput)?
+  private let completion: ((PhotoOuput?, [PhotoOuput]) -> Void)
   private var lastThumbnailImage: UIImage?
   private var lastStillImageData: Data?
   private var deferredPhotoProxyData: Data?
@@ -19,10 +20,12 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
   init(
     isCameraPosition: AVCaptureDevice.Position,
     willCaptureLivePhoto: (() -> Void)? = nil,
-    completion: @escaping (PhotoOuput?) -> Void
+    photoOutputProcessor: ((PhotoOuput) -> PhotoOuput)? = nil,
+    completion: @escaping (PhotoOuput?, [PhotoOuput]) -> Void
   ) {
     self.isCameraPosition = isCameraPosition
     self.willCaptureLivePhoto = willCaptureLivePhoto
+    self.photoOutputProcessor = photoOutputProcessor
     self.completion = completion
   }
 
@@ -41,7 +44,7 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
   ) {
     guard error == nil else {
       logger.error("Deferred Photo Proxy Error: \(error)")
-      completion(nil)
+      completion(nil, [])
       return
     }
 
@@ -49,7 +52,7 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
       let imageData = deferredPhotoProxy.fileDataRepresentation()
     else {
       logger.error("Deferred proxy is nil or no data")
-      completion(nil)
+      completion(nil, [])
       return
     }
 
@@ -60,16 +63,22 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
         let thumbnail = UIImage(data: imageData)
       {
         logger.info("Live Photo: Saving deferred live photo (Proxy delegate).")
+        let originalPhotoOutput = PhotoOuput.livePhoto(thumbnail: thumbnail, imageData: imageData, videoData: movieData)
+        let photoOutput = process(originalPhotoOutput)
+        saveOriginalIfNeeded(originalPhotoOutput, isDeferredLivePhoto: true)
         PhotoLibraryHelpers.saveDeferredLivePhotoToPhotosLibrary(
-          proxyData: imageData,
+          proxyData: photoOutput.imageData,
           livePhotoMovieURL: livePhotoMovieURL
         )
 
-        completion(.livePhoto(thumbnail: thumbnail, imageData: imageData, videoData: movieData))
+        completion(photoOutput, sendOutputs(original: originalPhotoOutput, processed: photoOutput))
       }
     } else {
-      PhotoLibraryHelpers.saveProxyToPhotoLibrary(imageData)
-      completion(.basicPhoto(thumbnail: UIImage(data: imageData) ?? .init(), imageData: imageData))
+      let originalPhotoOutput = PhotoOuput.basicPhoto(thumbnail: UIImage(data: imageData) ?? .init(), imageData: imageData)
+      let photoOutput = process(originalPhotoOutput)
+      saveOriginalIfNeeded(originalPhotoOutput, isDeferredPhoto: true)
+      PhotoLibraryHelpers.saveProxyToPhotoLibrary(photoOutput.imageData)
+      completion(photoOutput, sendOutputs(original: originalPhotoOutput, processed: photoOutput))
     }
   }
 
@@ -80,7 +89,7 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
   ) {
     guard error == nil else {
       logger.error("Error while capturing photo")
-      completion(nil)
+      completion(nil, [])
       return
     }
 
@@ -89,7 +98,7 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
       let image = UIImage(data: imageData)
     else {
       logger.error("Image not fetched.")
-      completion(nil)
+      completion(nil, [])
       return
     }
 
@@ -97,8 +106,11 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
     lastStillImageData = imageData
 
     if !isLivePhoto {
-      PhotoLibraryHelpers.saveToPhotoLibrary(imageData)
-      completion(.basicPhoto(thumbnail: image, imageData: imageData))
+      let originalPhotoOutput = PhotoOuput.basicPhoto(thumbnail: image, imageData: imageData)
+      let photoOutput = process(originalPhotoOutput)
+      saveOriginalIfNeeded(originalPhotoOutput)
+      PhotoLibraryHelpers.saveToPhotoLibrary(photoOutput.imageData)
+      completion(photoOutput, sendOutputs(original: originalPhotoOutput, processed: photoOutput))
     }
   }
 
@@ -113,7 +125,7 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
 
     guard error == nil else {
       logger.error("Error capturing Live Photo movie: \(error)")
-      completion(nil)
+      completion(nil, [])
       return
     }
 
@@ -125,11 +137,18 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
       let thumbnail = UIImage(data: deferredPhotoProxyData)
     {
       logger.info("Live Photo: Saving deferred live photo (Movie delegate).")
+      let originalPhotoOutput = PhotoOuput.livePhoto(
+        thumbnail: thumbnail,
+        imageData: deferredPhotoProxyData,
+        videoData: movieData
+      )
+      let photoOutput = process(originalPhotoOutput)
+      saveOriginalIfNeeded(originalPhotoOutput, isDeferredLivePhoto: true)
       PhotoLibraryHelpers.saveDeferredLivePhotoToPhotosLibrary(
-        proxyData: deferredPhotoProxyData,
+        proxyData: photoOutput.imageData,
         livePhotoMovieURL: outputFileURL
       )
-      completion(.livePhoto(thumbnail: thumbnail, imageData: deferredPhotoProxyData, videoData: movieData))
+      completion(photoOutput, sendOutputs(original: originalPhotoOutput, processed: photoOutput))
       return
     }
 
@@ -139,12 +158,54 @@ final class CameraDelegate: NSObject, AVCapturePhotoCaptureDelegate {
       let movieData = try? Data(contentsOf: outputFileURL)
     {
       logger.info("Live Photo: Saving standard live photo (Movie delegate).")
+      let originalPhotoOutput = PhotoOuput.livePhoto(
+        thumbnail: lastThumbnailImage,
+        imageData: lastStillImageData,
+        videoData: movieData
+      )
+      let photoOutput = process(originalPhotoOutput)
+      saveOriginalIfNeeded(originalPhotoOutput)
       PhotoLibraryHelpers.saveLivePhotoToPhotosLibrary(
-        stillImageData: lastStillImageData,
+        stillImageData: photoOutput.imageData,
         livePhotoMovieURL: outputFileURL
       )
-      completion(.livePhoto(thumbnail: lastThumbnailImage, imageData: lastStillImageData, videoData: movieData))
+      completion(photoOutput, sendOutputs(original: originalPhotoOutput, processed: photoOutput))
       return
+    }
+  }
+}
+
+private extension CameraDelegate {
+  func process(_ photoOutput: PhotoOuput) -> PhotoOuput {
+    photoOutputProcessor?(photoOutput) ?? photoOutput
+  }
+
+  func sendOutputs(original: PhotoOuput, processed: PhotoOuput) -> [PhotoOuput] {
+    guard photoOutputProcessor != nil else { return [processed] }
+    return [original, processed]
+  }
+
+  func saveOriginalIfNeeded(
+    _ photoOutput: PhotoOuput,
+    isDeferredPhoto: Bool = false,
+    isDeferredLivePhoto: Bool = false
+  ) {
+    guard photoOutputProcessor != nil else { return }
+
+    switch photoOutput {
+    case .basicPhoto(_, let imageData):
+      if isDeferredPhoto {
+        PhotoLibraryHelpers.saveProxyToPhotoLibrary(imageData)
+      } else {
+        PhotoLibraryHelpers.saveToPhotoLibrary(imageData)
+      }
+
+    case .livePhoto(_, let imageData, let videoData):
+      if isDeferredLivePhoto {
+        PhotoLibraryHelpers.saveDeferredLivePhotoToPhotosLibrary(proxyData: imageData, livePhotoMovieData: videoData)
+      } else {
+        PhotoLibraryHelpers.saveLivePhotoToPhotosLibrary(stillImageData: imageData, livePhotoMovieData: videoData)
+      }
     }
   }
 }

--- a/QueenCam/QueenCam/Presentation/ViewModels/Camera/CameraManager.swift
+++ b/QueenCam/QueenCam/Presentation/ViewModels/Camera/CameraManager.swift
@@ -23,6 +23,7 @@ final class CameraManager: NSObject {
   private let previewCaptureService: PreviewCaptureService
   // 네트워크 송수신
   let networkService: NetworkServiceProtocol
+  private let photoOverlayCompositingService: PhotoOverlayCompositingServiceProtocol
   var cancellables: Set<AnyCancellable> = []
 
   var position: AVCaptureDevice.Position = .back
@@ -45,9 +46,14 @@ final class CameraManager: NSObject {
   // 렌즈 변경 상태를 관찰하기 위한 옵저버
   private var lensChangeObserver: NSKeyValueObservation?
 
-  init(previewCaptureService: PreviewCaptureService, networkService: NetworkServiceProtocol) {
+  init(
+    previewCaptureService: PreviewCaptureService,
+    networkService: NetworkServiceProtocol,
+    photoOverlayCompositingService: PhotoOverlayCompositingServiceProtocol = PhotoOverlayCompositingService()
+  ) {
     self.previewCaptureService = previewCaptureService
     self.networkService = networkService
+    self.photoOverlayCompositingService = photoOverlayCompositingService
 
     super.init()
 
@@ -92,7 +98,21 @@ final class CameraManager: NSObject {
     }
   }
 
-  func capturePhoto() {
+  func capturePhoto(drawableStrokes: [DrawableStroke] = []) {
+    guard !drawableStrokes.isEmpty else {
+      performCapturePhoto(allowsDeferredPhotoDelivery: true)
+      return
+    }
+
+    performCapturePhoto(allowsDeferredPhotoDelivery: false) { [photoOverlayCompositingService] photoOutput in
+      photoOverlayCompositingService.composite(photoOutput: photoOutput, strokes: drawableStrokes)
+    }
+  }
+
+  private func performCapturePhoto(
+    allowsDeferredPhotoDelivery: Bool,
+    photoOutputProcessor: ((PhotoOuput) -> PhotoOuput)? = nil
+  ) {
     captureSessionQueue.async { [weak self] in
       guard let self else { return }
 
@@ -119,6 +139,10 @@ final class CameraManager: NSObject {
         photoSettings.livePhotoMovieFileURL = URL.movieFileURL
       }
 
+      if self.photoOutput.isAutoDeferredPhotoDeliverySupported {
+        self.photoOutput.isAutoDeferredPhotoDeliveryEnabled = allowsDeferredPhotoDelivery
+      }
+
       // 1
       let uniqueID = photoSettings.uniqueID
 
@@ -127,8 +151,9 @@ final class CameraManager: NSObject {
         isCameraPosition: self.position,
         willCaptureLivePhoto: { [weak self] in
           self?.onWillCaptureLivePhoto?()
-        }
-      ) { [weak self] photoOutput in
+        },
+        photoOutputProcessor: photoOutputProcessor
+      ) { [weak self] photoOutput, photoOutputsToSend in
         guard let self else { return }
 
         // 5
@@ -154,7 +179,9 @@ final class CameraManager: NSObject {
           self.onDidFinishCapture?()
         }
 
-        self.sendPhoto(photoOutput)
+        photoOutputsToSend.forEach {
+          self.sendPhoto($0)
+        }
       }
 
       // 3

--- a/QueenCam/QueenCam/Presentation/ViewModels/Camera/CameraViewModel.swift
+++ b/QueenCam/QueenCam/Presentation/ViewModels/Camera/CameraViewModel.swift
@@ -11,6 +11,7 @@ final class CameraViewModel {
   let cameraManager: CameraManager
   let networkService: NetworkServiceProtocol
   let cameraSettingsService: CameraSettingsServiceProtocol
+  private let guidingStrokeRepository: GuidingStrokeRepositoryProtocol
   
   var isCameraPermissionGranted = false
   var isPhotosPermissionGranted = false
@@ -45,10 +46,12 @@ final class CameraViewModel {
     previewCaptureService: PreviewCaptureService,
     networkService: NetworkServiceProtocol,
     cameraSettingsService: CameraSettingsServiceProtocol,
-    notificationService: NotificationServiceProtocol
+    notificationService: NotificationServiceProtocol,
+    guidingStrokeRepository: GuidingStrokeRepositoryProtocol = DependencyContainer.defaultContainer.guidingStrokeRepository
   ) {
     self.networkService = networkService
     self.cameraSettingsService = cameraSettingsService
+    self.guidingStrokeRepository = guidingStrokeRepository
     self.cameraManager = CameraManager(
       previewCaptureService: previewCaptureService,
       networkService: networkService
@@ -141,7 +144,12 @@ final class CameraViewModel {
   
   func capturePhoto() {
     traceShutterPressedEvent()
-    cameraManager.capturePhoto()
+    guard cameraSettingsService.saveGuidingOverlayImageOn else {
+      cameraManager.capturePhoto()
+      return
+    }
+
+    cameraManager.capturePhoto(drawableStrokes: guidingStrokeRepository.captureDrawableStrokes())
   }
   
   func setZoom(factor: CGFloat, ramp: Bool) {

--- a/QueenCam/QueenCam/Presentation/ViewModels/Camera/PhotoLibraryHelpers.swift
+++ b/QueenCam/QueenCam/Presentation/ViewModels/Camera/PhotoLibraryHelpers.swift
@@ -58,6 +58,15 @@ struct PhotoLibraryHelpers {
     }
   }
 
+  static func saveLivePhotoToPhotosLibrary(stillImageData: Data, livePhotoMovieData: Data) {
+    do {
+      let livePhotoMovieURL = try writeLivePhotoMovieDataToTemporaryFile(livePhotoMovieData)
+      saveLivePhotoToPhotosLibrary(stillImageData: stillImageData, livePhotoMovieURL: livePhotoMovieURL)
+    } catch {
+      logger.error("Failed to prepare Live Photo movie file: \(error.localizedDescription)")
+    }
+  }
+
   static func saveDeferredLivePhotoToPhotosLibrary(proxyData: Data, livePhotoMovieURL: URL) {
     PHPhotoLibrary.shared().performChanges({
       let creationRequest = PHAssetCreationRequest.forAsset()
@@ -75,5 +84,27 @@ struct PhotoLibraryHelpers {
         self.logger.error("Failed to save Deferred Live Photo: \(error.localizedDescription)")
       }
     }
+  }
+
+  static func saveDeferredLivePhotoToPhotosLibrary(proxyData: Data, livePhotoMovieData: Data) {
+    do {
+      let livePhotoMovieURL = try writeLivePhotoMovieDataToTemporaryFile(livePhotoMovieData)
+      saveDeferredLivePhotoToPhotosLibrary(proxyData: proxyData, livePhotoMovieURL: livePhotoMovieURL)
+    } catch {
+      logger.error("Failed to prepare deferred Live Photo movie file: \(error.localizedDescription)")
+    }
+  }
+}
+
+private extension PhotoLibraryHelpers {
+  static func writeLivePhotoMovieDataToTemporaryFile(_ movieData: Data) throws -> URL {
+    // Live Photo 저장은 paired video 파일을 Photos 라이브러리로 이동시킨다.
+    // 원본 Live Photo와 오버레이 합성 Live Photo를 함께 저장할 때 같은 movie URL을 재사용하면
+    // 먼저 완료된 저장 요청이 파일을 이동시켜 나머지 저장 요청의 paired video가 사라진다.
+    // 따라서 캡처된 movie data를 별도의 임시 파일로 복제해
+    // 각 Live Photo asset이 독립적인 파일을 소유하게 한다.
+    let livePhotoMovieURL = URL.movieFileURL
+    try movieData.write(to: livePhotoMovieURL)
+    return livePhotoMovieURL
   }
 }

--- a/QueenCam/QueenCam/Presentation/ViewModels/Camera/PhotoOuput.swift
+++ b/QueenCam/QueenCam/Presentation/ViewModels/Camera/PhotoOuput.swift
@@ -11,4 +11,22 @@ import UIKit
 enum PhotoOuput {
   case basicPhoto(thumbnail: UIImage, imageData: Data)
   case livePhoto(thumbnail: UIImage, imageData: Data, videoData: Data)
+
+  var thumbnail: UIImage {
+    switch self {
+    case .basicPhoto(let thumbnail, _):
+      return thumbnail
+    case .livePhoto(let thumbnail, _, _):
+      return thumbnail
+    }
+  }
+
+  var imageData: Data {
+    switch self {
+    case .basicPhoto(_, let imageData):
+      return imageData
+    case .livePhoto(_, let imageData, _):
+      return imageData
+    }
+  }
 }

--- a/QueenCam/QueenCam/Presentation/ViewModels/Guiding/Pen/PenViewModel.swift
+++ b/QueenCam/QueenCam/Presentation/ViewModels/Guiding/Pen/PenViewModel.swift
@@ -30,128 +30,67 @@ final class PenViewModel {
   private var hasShownPenReferenceLargeToast: Bool = false
   private var hasShownMagicPenReferenceLargeToast: Bool = false
 
-  // MARK: - 네트워크
-  let networkService: NetworkServiceProtocol
-  var cancellables: Set<AnyCancellable> = []
+  // MARK: - Stroke Repository
+  private let strokeRepository: GuidingStrokeRepositoryProtocol
+  private var strokeSnapshotTask: Task<Void, Never>?
 
   // MARK: - Toast
   let notificationService: NotificationServiceProtocol
 
   init(
-    networkService: NetworkServiceProtocol = DependencyContainer.defaultContainer.networkService,
+    strokeRepository: GuidingStrokeRepositoryProtocol = DependencyContainer.defaultContainer.guidingStrokeRepository,
     notificationService: NotificationServiceProtocol = DependencyContainer.defaultContainer.notificationService
   ) {
-    self.networkService = networkService
+    self.strokeRepository = strokeRepository
     self.notificationService = notificationService
 
-    bind()
+    bindStrokeSnapshots()
+  }
+
+  deinit {
+    strokeSnapshotTask?.cancel()
   }
 
   // MARK: - 드로잉 시작/진행 업데이트
   func add(initialPoints: [CGPoint], isMagicPen: Bool, author: Role) -> UUID {
-    let stroke = Stroke(points: initialPoints, isMagicPen: isMagicPen, author: author, endDrawing: false)
-    strokes.append(stroke)
-
     if author == myRole && hasEverDrawn == false {
       hasEverDrawn = true
     }
 
-    // Send to network
-    sendPenCommand(command: .add(stroke: stroke))
-    return stroke.id
+    return strokeRepository.add(initialPoints: initialPoints, isMagicPen: isMagicPen, author: author)
   }
 
   /// 진행 중 스트로크의 포인트를 갱신 +  .replace 이벤트를 전송
   func updateStroke(id: UUID, points: [CGPoint], endDrawing: Bool) {
-    guard let strokeIndex = strokes.firstIndex(where: { $0.id == id }) else { return }
-    if strokes[strokeIndex].author != myRole { return }
-    strokes[strokeIndex].points = points
-    strokes[strokeIndex].endDrawing = endDrawing
-    // Send to network
-    sendPenCommand(command: .replace(stroke: strokes[strokeIndex]))
+    strokeRepository.updateStroke(id: id, points: points, endDrawing: endDrawing, author: myRole)
   }
   // MARK: - 세션 종료 후 Stroke 저장
   /// 펜 툴 해제(세션 종료) 시 본인 stroke를 strokes에서 persistedStrokes로 이관
   func saveStroke() {
-    // strokes에 있는 본인 stroke 찾기
-    let myStrokes = strokes.filter { $0.author == myRole }
-    if !myStrokes.isEmpty {
-      // 해당 stroke를 persistedStrokes로 append
-      persistedStrokes.append(contentsOf: myStrokes)
-      // 해당 stroke를 strokes에서 삭제(remove)
-      strokes.removeAll { $0.author == myRole }
-    }
-    // deleteStrokes에 있는 본인 stroke 찾기 => 전체 삭제
-    let myDeleteStrokes = deleteStrokes.flatMap { $0 }.filter { $0.author == myRole }
-    if !myDeleteStrokes.isEmpty {
-      // 해당 stroke를 deleteStrokes에서 삭제 - 복구 불가
-      for i in deleteStrokes.indices {
-        deleteStrokes[i].removeAll { $0.author == myRole }
-      }
-    }
+    strokeRepository.saveStroke(for: myRole)
   }
 
   // MARK: - 스트로크 삭제
   /// 펜 가이딩 개별 획(stroke)  삭제 - 매직펜
   func remove(_ id: UUID) {
-    guard
-      let target = strokes.first(where: { $0.id == id }),
-      target.author == myRole
-    else { return }
-
-    strokes.removeAll { $0.id == id }
-
-    // Send to network
-    sendPenCommand(command: .remove(id: id))
+    strokeRepository.remove(id, author: myRole)
   }
 
   /// 본인이 생성한 펜 가이딩 전체 삭제
   func deleteAll() {
-    // 내가 생성한 stroke 배열과 id 배열
-    let myStrokes = strokes.filter { $0.author == myRole }
-    let myPersistedStrokes = persistedStrokes.filter { $0.author == myRole }
-    let allMyStrokes = myStrokes + myPersistedStrokes
-
-    if !allMyStrokes.isEmpty {
-      deleteStrokes.append(myStrokes)  // 전체 삭제 이후, Undo는 현재 세션에 작업한 strokes만 포함
-    }
-
-    let myIds = allMyStrokes.map(\.id)
-
-    strokes.removeAll { $0.author == myRole }
-    persistedStrokes.removeAll { $0.author == myRole }
-
-    //   Send to network
-    for id in myIds {
-      sendPenCommand(command: .remove(id: id))
-    }
+    strokeRepository.deleteAll(for: myRole)
   }
 
   /// 펜 가이딩 초기화
   func reset() {
-    strokes.removeAll()
-    persistedStrokes.removeAll()
     hasEverDrawn = false
 
-    // Send to network
-    sendPenCommand(command: .reset)
+    strokeRepository.reset()
   }
 
   // MARK: - 스트로크 실행취소/재실행
   func undo() {
-    if strokes.isEmpty, let recentDeleteStrokes = deleteStrokes.popLast() {
-      strokes.append(contentsOf: recentDeleteStrokes)
-      for stroke in recentDeleteStrokes {
-        sendPenCommand(command: .add(stroke: stroke))
-      }
-      return
-    }
-    guard let index = strokes.lastIndex(where: { $0.author == myRole }) else { return }
-
-    let last = strokes.remove(at: index)
-
-    // Send to network
-    sendPenCommand(command: .remove(id: last.id))
+    strokeRepository.undo(for: myRole)
   }
 
   // MARK: - 토스트
@@ -191,75 +130,21 @@ final class PenViewModel {
   }
 }
 
-// MARK: Receiving network event
 extension PenViewModel {
-  private func bind() {
-    networkService.networkEventPublisher
-      .receive(on: RunLoop.main)
-      .compactMap { $0 }
-      .sink { [weak self] event in
-        switch event {
-        case .penUpdated(let eventType):
-          self?.handlePenEvent(eventType: eventType)
-        default: break
+  private func bindStrokeSnapshots() {
+    let initialSnapshot = strokeRepository.currentSnapshot()
+    persistedStrokes = initialSnapshot.persistedStrokes
+    strokes = initialSnapshot.strokes
+    deleteStrokes = initialSnapshot.deleteStrokes
+
+    strokeSnapshotTask = Task { [weak self, strokeRepository] in
+      for await snapshot in strokeRepository.snapshots {
+        await MainActor.run {
+          self?.persistedStrokes = snapshot.persistedStrokes
+          self?.strokes = snapshot.strokes
+          self?.deleteStrokes = snapshot.deleteStrokes
         }
       }
-      .store(in: &cancellables)
-  }
-
-  private func handlePenEvent(eventType: PenEventType) {
-    switch eventType {
-    case .add(let penPayload):
-      let stroke = PenMapper.convert(payload: penPayload)
-
-      if !strokes.contains(where: { $0.id == stroke.id }) {
-        strokes.append(stroke)
-      }
-    case .replace(let penPayload):
-      let replaceTo = PenMapper.convert(payload: penPayload)
-      let targetId = replaceTo.id
-
-      strokes = strokes.map { stroke in
-        if stroke.id == targetId {
-          return replaceTo
-        }
-        return stroke
-      }
-    case .delete(let id):
-      strokes.removeAll { $0.id == id }
-      persistedStrokes.removeAll { $0.id == id }
-    case .reset:
-      strokes.removeAll()
-      hasEverDrawn = false
-    }
-  }
-}
-
-// MARK: Sending network event
-private enum PenNetworkCommand {
-  case add(stroke: Stroke)
-  case replace(stroke: Stroke)
-  case remove(id: UUID)
-  case reset
-}
-
-extension PenViewModel {
-  private func sendPenCommand(command: PenNetworkCommand) {
-    var sendingEventType: PenEventType
-
-    switch command {
-    case .add(let stroke):
-      sendingEventType = .add(PenMapper.convert(stroke: stroke))
-    case .replace(let stroke):
-      sendingEventType = .replace(PenMapper.convert(stroke: stroke))
-    case .remove(let id):
-      sendingEventType = .delete(id: id)
-    case .reset:
-      sendingEventType = .reset
-    }
-    Task.detached { [weak self] in
-      guard let self else { return }
-      await self.networkService.send(for: .penUpdated(sendingEventType))
     }
   }
 }

--- a/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift
@@ -10,10 +10,12 @@ import SwiftUI
 struct SettingsMainView {
   let navigationRouter: NavigationRouter
   let role: Role?
+  private let cameraSettingsService: CameraSettingsServiceProtocol
 
   @State private var safariSheetItem: SafariSheetItem?
   @State private var guideSheetItem: GuideSheetItem?
   @State private var isConfirmingRole = false
+  @State private var isSaveGuidingOverlayImageOn = false
 
   // MARK: - URLs
   let vocPageURL = URL(
@@ -26,6 +28,16 @@ struct SettingsMainView {
   // MARK: - Computed
   var appVersion: String {
     Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+  }
+
+  init(
+    navigationRouter: NavigationRouter,
+    role: Role?,
+    cameraSettingsService: CameraSettingsServiceProtocol = DependencyContainer.defaultContainer.cameraSettingServcice
+  ) {
+    self.navigationRouter = navigationRouter
+    self.role = role
+    self.cameraSettingsService = cameraSettingsService
   }
 }
 
@@ -50,6 +62,11 @@ extension SettingsMainView: View {
         .padding(.horizontal, 20)
 
         HeaderSeparator()
+
+        SettingSection(title: "촬영") {
+          SettingToggleSectionItem(title: "펜 가이드 함께 저장", isOn: $isSaveGuidingOverlayImageOn)
+        }
+        .padding(.horizontal, 20)
 
         SettingSection(title: "고객센터") {
           SettingSectionItem {
@@ -109,6 +126,12 @@ extension SettingsMainView: View {
         guideSheetItem = GuideSheetItem(role: .model)
       }
       Button("취소", role: .cancel) {}
+    }
+    .onAppear {
+      isSaveGuidingOverlayImageOn = cameraSettingsService.saveGuidingOverlayImageOn
+    }
+    .onChange(of: isSaveGuidingOverlayImageOn) { _, newValue in
+      cameraSettingsService.saveGuidingOverlayImageOn = newValue
     }
   }
 }

--- a/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/UIComponents/SettingToggleSectionItem.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/UIComponents/SettingToggleSectionItem.swift
@@ -1,0 +1,35 @@
+//
+//  SettingToggleSectionItem.swift
+//  QueenCam
+//
+//  Created by 임영택 on 6/21/26.
+//
+
+import SwiftUI
+
+struct SettingToggleSectionItem {
+  let title: LocalizedStringKey
+  @Binding var isOn: Bool
+}
+
+extension SettingToggleSectionItem: View {
+  var body: some View {
+    Toggle(isOn: $isOn) {
+      Text(title)
+        .typo(.sb16)
+        .foregroundStyle(.offWhite)
+    }
+    .tint(.photographerPrimary)
+  }
+}
+
+#Preview {
+  @Previewable @State var isOn = true
+
+  ZStack {
+    Color.black
+
+    SettingToggleSectionItem(title: "펜 가이드 함께 저장", isOn: $isOn)
+      .padding(20)
+  }
+}

--- a/QueenCam/QueenCam/Presentation/Views/Guiding/Pen/PenWriteView.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Guiding/Pen/PenWriteView.swift
@@ -26,10 +26,6 @@ struct PenWriteView: View {
   /// 작성 중인 스트로크 ID
   @State private var currentStrokeID: UUID?
 
-  private var topColor = Color.offWhite
-  private var photographerColor = Color.photographerPrimary
-  private var modelColor = Color.modelPrimary
-
   var body: some View {
     GeometryReader { geo in
       ZStack {
@@ -38,19 +34,10 @@ struct PenWriteView: View {
 
         // MARK: - 현재 그리고 있는 Stroke
         let author = role ?? .photographer
-        let outerColor = (author == .model) ? modelColor : photographerColor
         // 1) 일반펜
         if tempPoints.count > 1, !isMagicPen {
           Canvas { context, _ in
-            drawTempPoints(
-              context: context,
-              size: geo.size,
-              points: tempPoints,
-              layers: [
-                .stroke(color: topColor, width: 10),
-                .stroke(color: outerColor, width: 7)
-              ]
-            )
+            drawNormalTempPoints(context: context, size: geo.size, points: tempPoints, author: author)
           }
           .background(.clear)
         }
@@ -59,6 +46,7 @@ struct PenWriteView: View {
         // 매직펜 Blur 레이어
         Canvas { context, _ in
           if tempPoints.count > 1, isMagicPen {
+            let outerColor = author == .model ? Color.modelPrimary : .photographerPrimary
             drawTempPoints(
               context: context,
               size: geo.size,
@@ -170,5 +158,12 @@ private extension PenWriteView {
         context.stroke(path, with: .color(color), style: layer.style)
       }
     }
+  }
+
+  func drawNormalTempPoints(context: GraphicsContext, size: CGSize, points: [CGPoint], author: Role) {
+    let path = StrokeOverlayGeometry.path(from: points, in: size)
+    let style = StrokeRenderStyleResolver.normalStrokeStyle(for: author)
+    context.stroke(path, with: .color(style.backgroundColor), style: style.backgroundStrokeStyle)
+    context.stroke(path, with: .color(style.foregroundColor), style: style.foregroundStrokeStyle)
   }
 }

--- a/QueenCam/QueenCam/Presentation/Views/Guiding/Pen/Stroke/SingleStrokeView.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Guiding/Pen/Stroke/SingleStrokeView.swift
@@ -16,18 +16,17 @@ struct SingleStrokeView: View {
 
   var body: some View {
     Canvas { context, _ in
-      let outerColor = (stroke.author == .model) ? Color.modelPrimary : .photographerPrimary
-      var path = Path()
-      path.addLines(stroke.absolutePoints(in: geoSize))
+      let style = StrokeRenderStyleResolver.normalStrokeStyle(for: stroke.author)
+      let path = StrokeOverlayGeometry.path(from: stroke.points, in: geoSize)
       context.stroke(
         path,
-        with: .color(.offWhite),
-        style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .round)
+        with: .color(style.backgroundColor),
+        style: style.backgroundStrokeStyle
       )
       context.stroke(
         path,
-        with: .color(outerColor),
-        style: StrokeStyle(lineWidth: 7, lineCap: .round, lineJoin: .round)
+        with: .color(style.foregroundColor),
+        style: style.foregroundStrokeStyle
       )
     }
   }

--- a/QueenCam/QueenCam/Services/Camera/CameraSettingsService.swift
+++ b/QueenCam/QueenCam/Services/Camera/CameraSettingsService.swift
@@ -4,12 +4,14 @@ final class CameraSettingsService: CameraSettingsServiceProtocol {
   private let livePhotoKey = "livePhotoOn"
   private let gridKey = "gridOn"
   private let flashKey = "flashMode"
+  private let saveGuidingOverlayImageKey = "saveGuidingOverlayImageOn"
 
   init() {
     UserDefaults.standard.register(defaults: [
       livePhotoKey: false,
       gridKey: false,
-      flashKey: FlashMode.off.rawValue
+      flashKey: FlashMode.off.rawValue,
+      saveGuidingOverlayImageKey: true
     ])
   }
 
@@ -37,6 +39,15 @@ final class CameraSettingsService: CameraSettingsServiceProtocol {
     }
     set {
       UserDefaults.standard.set(newValue.rawValue, forKey: flashKey)
+    }
+  }
+
+  var saveGuidingOverlayImageOn: Bool {
+    get {
+      UserDefaults.standard.bool(forKey: saveGuidingOverlayImageKey)
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: saveGuidingOverlayImageKey)
     }
   }
 }

--- a/QueenCam/QueenCam/Services/Camera/CameraSettingsServiceProtocol.swift
+++ b/QueenCam/QueenCam/Services/Camera/CameraSettingsServiceProtocol.swift
@@ -10,4 +10,5 @@ protocol CameraSettingsServiceProtocol: AnyObject {
   var livePhotoOn: Bool { get set }
   var gridOn: Bool { get set }
   var flashMode: FlashMode { get set }
+  var saveGuidingOverlayImageOn: Bool { get set }
 }

--- a/QueenCam/QueenCam/Services/Camera/Overlay/PhotoOverlayCompositingService.swift
+++ b/QueenCam/QueenCam/Services/Camera/Overlay/PhotoOverlayCompositingService.swift
@@ -1,0 +1,193 @@
+//
+//  PhotoOverlayCompositingService.swift
+//  QueenCam
+//
+//  Created by 임영택 on 6/21/26.
+//
+
+import AVFoundation
+import Foundation
+import ImageIO
+import UIKit
+import UniformTypeIdentifiers
+
+final class PhotoOverlayCompositingService: PhotoOverlayCompositingServiceProtocol {
+  private static let livePhotoMakerAppleAssetIdentifierKey = "17"
+  private static let quickTimeContentIdentifierKey = "com.apple.quicktime.content.identifier"
+  private static let jpegCompressionQuality = 0.95
+
+  // 호출부는 프로토콜을 통해 테스트 대역으로 교체할 수 있도록 인스턴스 메서드만 바라본다.
+  // 실제 합성 과정 중 인스턴스 상태가 필요 없는 metadata/JPEG 변환 로직은 static helper로 분리한다.
+  func composite(photoOutput: PhotoOuput, strokes: [DrawableStroke]) -> PhotoOuput {
+    guard !strokes.isEmpty else { return photoOutput }
+
+    switch photoOutput {
+    case .basicPhoto(_, let imageData):
+      guard
+        let image = makeCompositeImage(from: imageData, strokes: strokes),
+        let compositeData = Self.makeJPEGData(from: image, originalImageData: imageData)
+      else { return photoOutput }
+
+      return .basicPhoto(thumbnail: image, imageData: compositeData)
+    case .livePhoto(_, let imageData, let videoData):
+      // Live Photo는 still image와 paired video가 같은 content identifier를 가져야 Photos에서 하나의 자산으로 묶인다.
+      // 합성 과정에서 still image를 새 JPEG로 다시 쓰면 MakerApple metadata가 사라질 수 있으므로,
+      // 원본 still 또는 paired video에서 identifier를 읽어 새 JPEG metadata에 다시 심는다.
+      let assetIdentifier = Self.livePhotoAssetIdentifier(from: imageData)
+        ?? Self.livePhotoAssetIdentifier(fromVideoData: videoData)
+
+      guard
+        let assetIdentifier,
+        let image = makeCompositeImage(from: imageData, strokes: strokes),
+        let compositeData = Self.makeJPEGData(
+          from: image,
+          originalImageData: imageData,
+          livePhotoAssetIdentifier: assetIdentifier
+        )
+      else { return photoOutput }
+
+      return .livePhoto(thumbnail: image, imageData: compositeData, videoData: videoData)
+    }
+  }
+}
+
+private extension PhotoOverlayCompositingService {
+  func makeCompositeImage(from imageData: Data, strokes: [DrawableStroke]) -> UIImage? {
+    guard let image = UIImage(data: imageData) else { return nil }
+
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = image.scale
+    format.opaque = true
+
+    let imageSize = image.size
+    let imageRect = CGRect(origin: .zero, size: imageSize)
+    let overlayRect = StrokeOverlayGeometry.aspectFitRect(in: imageRect)
+    let lineScale = StrokeOverlayGeometry.lineScale(for: overlayRect)
+
+    return UIGraphicsImageRenderer(size: imageSize, format: format).image { rendererContext in
+      image.draw(in: imageRect)
+
+      let context = rendererContext.cgContext
+      for stroke in strokes {
+        drawNormalStroke(
+          points: stroke.points,
+          author: stroke.author,
+          in: context,
+          overlayRect: overlayRect,
+          lineScale: lineScale
+        )
+      }
+    }
+  }
+
+  func drawNormalStroke(
+    points: [CGPoint],
+    author: Role,
+    in context: CGContext,
+    overlayRect: CGRect,
+    lineScale: CGFloat
+  ) {
+    let path = StrokeOverlayGeometry.bezierPath(from: points, in: overlayRect)
+    let style = StrokeRenderStyleResolver.normalStrokeStyle(for: author, lineScale: lineScale)
+
+    stroke(path, in: context, color: style.backgroundUIColor, width: style.backgroundLineWidth)
+    stroke(path, in: context, color: style.foregroundUIColor, width: style.foregroundLineWidth)
+  }
+
+  func stroke(_ path: UIBezierPath, in context: CGContext, color: UIColor, width: CGFloat) {
+    context.saveGState()
+    color.setStroke()
+    path.lineWidth = width
+    path.lineCapStyle = .round
+    path.lineJoinStyle = .round
+    path.stroke()
+    context.restoreGState()
+  }
+}
+
+private extension PhotoOverlayCompositingService {
+  // 이미지 metadata와 JPEG 재작성은 인스턴스 상태와 무관하다.
+  // 프로토콜 진입점은 유지하되, 순수 변환에 가까운 세부 로직은 static으로 두어 의존성을 좁힌다.
+  static func makeJPEGData(
+    from image: UIImage,
+    originalImageData: Data,
+    livePhotoAssetIdentifier: String? = nil
+  ) -> Data? {
+    guard let cgImage = image.cgImage else { return nil }
+
+    let data = NSMutableData()
+    guard let destination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil) else {
+      return nil
+    }
+
+    // UIImage(data:)로 원본 JPEG를 읽으면 metadata의 orientation이 이미 반영된 상태로 메모리에 로드된다.
+    // 이후 UIImage.draw(in:)로 합성 이미지를 만들면 회전이 적용된 픽셀 자체가 새 이미지에 기록된다.
+    // 이 상태에서 원본 orientation metadata를 다시 복사하면 Photos가 저장된 픽셀을 한 번 더 회전해서 보여준다.
+    // 따라서 촬영 시각/렌즈/기기 metadata는 보존하고, orientation metadata는 픽셀 기준인 .up으로 고정한다.
+    var properties = imageProperties(from: originalImageData)
+    properties[kCGImageDestinationLossyCompressionQuality as String] = jpegCompressionQuality
+    normalizeOrientation(in: &properties)
+
+    if let livePhotoAssetIdentifier {
+      // Live Photo still image의 pairing identifier는 Apple MakerNote의 비공개 key "17"에 들어간다.
+      // 새 JPEG를 만들면서 이 값이 빠지면 paired video와 같은 asset으로 묶이지 않아 저장 실패가 날 수 있다.
+      // 그래서 원본 still/video에서 읽은 identifier를 새 still metadata에 다시 주입한다.
+      var makerAppleDictionary = properties[kCGImagePropertyMakerAppleDictionary as String] as? [String: Any] ?? [:]
+      makerAppleDictionary[livePhotoMakerAppleAssetIdentifierKey] = livePhotoAssetIdentifier
+      properties[kCGImagePropertyMakerAppleDictionary as String] = makerAppleDictionary
+    }
+
+    CGImageDestinationAddImage(destination, cgImage, properties as CFDictionary)
+    guard CGImageDestinationFinalize(destination) else { return nil }
+
+    return data as Data
+  }
+
+  static func normalizeOrientation(in properties: inout [String: Any]) {
+    properties[kCGImagePropertyOrientation as String] = CGImagePropertyOrientation.up.rawValue
+
+    if var tiffDictionary = properties[kCGImagePropertyTIFFDictionary as String] as? [String: Any] {
+      tiffDictionary[kCGImagePropertyTIFFOrientation as String] = CGImagePropertyOrientation.up.rawValue
+      properties[kCGImagePropertyTIFFDictionary as String] = tiffDictionary
+    }
+  }
+
+  static func imageProperties(from imageData: Data) -> [String: Any] {
+    guard
+      let source = CGImageSourceCreateWithData(imageData as CFData, nil),
+      let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any]
+    else { return [:] }
+
+    return properties
+  }
+
+  static func livePhotoAssetIdentifier(from imageData: Data) -> String? {
+    let makerAppleDictionary = imageProperties(from: imageData)[kCGImagePropertyMakerAppleDictionary as String]
+      as? [String: Any]
+
+    return makerAppleDictionary?[livePhotoMakerAppleAssetIdentifierKey] as? String
+  }
+
+  static func livePhotoAssetIdentifier(fromVideoData videoData: Data) -> String? {
+    // Deferred/proxy 경로에서는 still image metadata에서 identifier를 못 읽을 수 있다.
+    // AVURLAsset은 URL 기반으로 QuickTime metadata를 읽기 때문에 video Data를 임시 mov 파일로 쓴 뒤 즉시 삭제한다.
+    let videoURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension(for: .quickTimeMovie)
+
+    do {
+      try videoData.write(to: videoURL)
+      defer { try? FileManager.default.removeItem(at: videoURL) }
+
+      let asset = AVURLAsset(url: videoURL)
+      return asset.metadata(forFormat: .quickTimeMetadata)
+        .first { item in
+          item.identifier == .quickTimeMetadataContentIdentifier
+            || item.key as? String == quickTimeContentIdentifierKey
+        }?
+        .stringValue
+    } catch {
+      return nil
+    }
+  }
+}

--- a/QueenCam/QueenCam/Services/Camera/Overlay/PhotoOverlayCompositingServiceProtocol.swift
+++ b/QueenCam/QueenCam/Services/Camera/Overlay/PhotoOverlayCompositingServiceProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  PhotoOverlayCompositingServiceProtocol.swift
+//  QueenCam
+//
+//  Created by 임영택 on 6/21/26.
+//
+
+import Foundation
+
+protocol PhotoOverlayCompositingServiceProtocol {
+  func composite(photoOutput: PhotoOuput, strokes: [DrawableStroke]) -> PhotoOuput
+}

--- a/QueenCam/QueenCam/Services/Camera/Overlay/StrokeOverlayRendering.swift
+++ b/QueenCam/QueenCam/Services/Camera/Overlay/StrokeOverlayRendering.swift
@@ -1,0 +1,136 @@
+//
+//  StrokeOverlayRendering.swift
+//  QueenCam
+//
+//  Created by 임영택 on 6/21/26.
+//
+
+import CoreGraphics
+import SwiftUI
+import UIKit
+
+struct StrokeRenderStyle {
+  let backgroundColor: Color
+  let foregroundColor: Color
+  let backgroundUIColor: UIColor
+  let foregroundUIColor: UIColor
+  let backgroundLineWidth: CGFloat
+  let foregroundLineWidth: CGFloat
+
+  var backgroundStrokeStyle: StrokeStyle {
+    StrokeStyle(lineWidth: backgroundLineWidth, lineCap: .round, lineJoin: .round)
+  }
+
+  var foregroundStrokeStyle: StrokeStyle {
+    StrokeStyle(lineWidth: foregroundLineWidth, lineCap: .round, lineJoin: .round)
+  }
+
+  func scaled(by scale: CGFloat) -> StrokeRenderStyle {
+    StrokeRenderStyle(
+      backgroundColor: backgroundColor,
+      foregroundColor: foregroundColor,
+      backgroundUIColor: backgroundUIColor,
+      foregroundUIColor: foregroundUIColor,
+      backgroundLineWidth: backgroundLineWidth * scale,
+      foregroundLineWidth: foregroundLineWidth * scale
+    )
+  }
+}
+
+enum StrokeRenderStyleResolver {
+  private static let normalBackgroundLineWidth: CGFloat = 10
+  private static let normalForegroundLineWidth: CGFloat = 7
+
+  static func normalStrokeStyle(for author: Role, lineScale: CGFloat = 1) -> StrokeRenderStyle {
+    StrokeRenderStyle(
+      backgroundColor: .offWhite,
+      foregroundColor: foregroundColor(for: author),
+      backgroundUIColor: .offWhite,
+      foregroundUIColor: foregroundUIColor(for: author),
+      backgroundLineWidth: normalBackgroundLineWidth * lineScale,
+      foregroundLineWidth: normalForegroundLineWidth * lineScale
+    )
+  }
+
+  private static func foregroundColor(for author: Role) -> Color {
+    switch author {
+    case .model:
+      return .modelPrimary
+    case .photographer:
+      return .photographerPrimary
+    }
+  }
+
+  private static func foregroundUIColor(for author: Role) -> UIColor {
+    switch author {
+    case .model:
+      return .modelPrimary
+    case .photographer:
+      return .photographerPrimary
+    }
+  }
+}
+
+enum StrokeOverlayGeometry {
+  static let logicalCanvasAspectRatio = CGSize(width: 3, height: 4)
+
+  // CameraPreviewArea가 iPhone에서 기준으로 쓰는 3:4 캔버스 폭이다.
+  // 사진 원본은 기기/방향/해상도에 따라 크기가 달라서, 저장 합성 시에는 이 논리 캔버스를 원본 이미지에 aspect-fit한다.
+  private static let logicalCanvasWidth: CGFloat = 377
+
+  static func lineScale(for overlayRect: CGRect) -> CGFloat {
+    max(
+      overlayRect.width / logicalCanvasWidth,
+      overlayRect.height / (logicalCanvasWidth * logicalCanvasAspectRatio.height / logicalCanvasAspectRatio.width)
+    )
+  }
+
+  static func aspectFitRect(aspectRatio: CGSize = logicalCanvasAspectRatio, in rect: CGRect) -> CGRect {
+    let targetRatio = aspectRatio.width / aspectRatio.height
+    let rectRatio = rect.width / rect.height
+
+    if rectRatio > targetRatio {
+      let width = rect.height * targetRatio
+      return CGRect(
+        x: rect.midX - width / 2,
+        y: rect.minY,
+        width: width,
+        height: rect.height
+      )
+    } else {
+      let height = rect.width / targetRatio
+      return CGRect(
+        x: rect.minX,
+        y: rect.midY - height / 2,
+        width: rect.width,
+        height: height
+      )
+    }
+  }
+
+  static func point(from normalizedPoint: CGPoint, in rect: CGRect) -> CGPoint {
+    CGPoint(
+      x: rect.minX + normalizedPoint.x * rect.width,
+      y: rect.minY + normalizedPoint.y * rect.height
+    )
+  }
+
+  static func path(from normalizedPoints: [CGPoint], in size: CGSize) -> Path {
+    var path = Path()
+    path.addLines(normalizedPoints.map { CGPoint(x: $0.x * size.width, y: $0.y * size.height) })
+    return path
+  }
+
+  static func bezierPath(from normalizedPoints: [CGPoint], in rect: CGRect) -> UIBezierPath {
+    let path = UIBezierPath()
+
+    guard let first = normalizedPoints.first else { return path }
+    path.move(to: point(from: first, in: rect))
+
+    for point in normalizedPoints.dropFirst() {
+      path.addLine(to: self.point(from: point, in: rect))
+    }
+
+    return path
+  }
+}

--- a/QueenCam/QueenCam/Services/Guiding/GuidingStrokeRepository.swift
+++ b/QueenCam/QueenCam/Services/Guiding/GuidingStrokeRepository.swift
@@ -1,0 +1,240 @@
+//
+//  GuidingStrokeRepository.swift
+//  QueenCam
+//
+//  Created by 임영택 on 6/21/26.
+//
+
+import Combine
+import CoreGraphics
+import Foundation
+
+final class GuidingStrokeRepository: GuidingStrokeRepositoryProtocol {
+  private var persistedStrokes: [Stroke] = []
+  private var strokes: [Stroke] = []
+  private var deleteStrokes: [[Stroke]] = []
+
+  private let networkService: NetworkServiceProtocol
+  private var cancellables: Set<AnyCancellable> = []
+
+  private let snapshotStream: AsyncStream<StrokeSnapshot>
+  private let snapshotContinuation: AsyncStream<StrokeSnapshot>.Continuation
+
+  var snapshots: AsyncStream<StrokeSnapshot> {
+    snapshotStream
+  }
+
+  init(networkService: NetworkServiceProtocol) {
+    self.networkService = networkService
+    let stream = AsyncStream.makeStream(of: StrokeSnapshot.self)
+    self.snapshotStream = stream.stream
+    self.snapshotContinuation = stream.continuation
+
+    bind()
+    publishSnapshot()
+  }
+
+  deinit {
+    snapshotContinuation.finish()
+  }
+
+  func currentSnapshot() -> StrokeSnapshot {
+    makeSnapshot()
+  }
+
+  func captureDrawableStrokes() -> [DrawableStroke] {
+    let snapshot = makeSnapshot()
+    return (snapshot.persistedStrokes + snapshot.strokes)
+      .filter { $0.points.count > 1 && !$0.isMagicPen }
+      .map {
+        DrawableStroke(
+          id: $0.id,
+          points: $0.points,
+          author: $0.author
+        )
+      }
+  }
+
+  @discardableResult
+  func add(initialPoints: [CGPoint], isMagicPen: Bool, author: Role) -> UUID {
+    let stroke = Stroke(points: initialPoints, isMagicPen: isMagicPen, author: author, endDrawing: false)
+    strokes.append(stroke)
+    publishSnapshot()
+    sendPenCommand(command: .add(stroke: stroke))
+    return stroke.id
+  }
+
+  func updateStroke(id: UUID, points: [CGPoint], endDrawing: Bool, author: Role) {
+    guard let strokeIndex = strokes.firstIndex(where: { $0.id == id }) else { return }
+    guard strokes[strokeIndex].author == author else { return }
+
+    strokes[strokeIndex].points = points
+    strokes[strokeIndex].endDrawing = endDrawing
+    publishSnapshot()
+    sendPenCommand(command: .replace(stroke: strokes[strokeIndex]))
+  }
+
+  func saveStroke(for author: Role) {
+    let myStrokes = strokes.filter { $0.author == author }
+    if !myStrokes.isEmpty {
+      persistedStrokes.append(contentsOf: myStrokes)
+      strokes.removeAll { $0.author == author }
+    }
+
+    let myDeleteStrokes = deleteStrokes.flatMap { $0 }.filter { $0.author == author }
+    if !myDeleteStrokes.isEmpty {
+      for i in deleteStrokes.indices {
+        deleteStrokes[i].removeAll { $0.author == author }
+      }
+    }
+
+    publishSnapshot()
+  }
+
+  func remove(_ id: UUID, author: Role) {
+    guard
+      let target = strokes.first(where: { $0.id == id }),
+      target.author == author
+    else { return }
+
+    strokes.removeAll { $0.id == id }
+    publishSnapshot()
+    sendPenCommand(command: .remove(id: id))
+  }
+
+  func deleteAll(for author: Role) {
+    let myStrokes = strokes.filter { $0.author == author }
+    let myPersistedStrokes = persistedStrokes.filter { $0.author == author }
+    let allMyStrokes = myStrokes + myPersistedStrokes
+
+    if !allMyStrokes.isEmpty {
+      deleteStrokes.append(myStrokes)
+    }
+
+    let myIds = allMyStrokes.map(\.id)
+
+    strokes.removeAll { $0.author == author }
+    persistedStrokes.removeAll { $0.author == author }
+    publishSnapshot()
+
+    for id in myIds {
+      sendPenCommand(command: .remove(id: id))
+    }
+  }
+
+  func reset() {
+    strokes.removeAll()
+    persistedStrokes.removeAll()
+    deleteStrokes.removeAll()
+    publishSnapshot()
+    sendPenCommand(command: .reset)
+  }
+
+  func undo(for author: Role) {
+    if strokes.isEmpty, let recentDeleteStrokes = deleteStrokes.popLast() {
+      strokes.append(contentsOf: recentDeleteStrokes)
+      publishSnapshot()
+      for stroke in recentDeleteStrokes {
+        sendPenCommand(command: .add(stroke: stroke))
+      }
+      return
+    }
+
+    guard let index = strokes.lastIndex(where: { $0.author == author }) else { return }
+    let last = strokes.remove(at: index)
+    publishSnapshot()
+    sendPenCommand(command: .remove(id: last.id))
+  }
+}
+
+// MARK: - Network Events
+
+private enum PenNetworkCommand {
+  case add(stroke: Stroke)
+  case replace(stroke: Stroke)
+  case remove(id: UUID)
+  case reset
+}
+
+private extension GuidingStrokeRepository {
+  func bind() {
+    networkService.networkEventPublisher
+      .receive(on: RunLoop.main)
+      .compactMap { $0 }
+      .sink { [weak self] event in
+        switch event {
+        case .penUpdated(let eventType):
+          self?.handlePenEvent(eventType: eventType)
+        default: break
+        }
+      }
+      .store(in: &cancellables)
+  }
+
+  func handlePenEvent(eventType: PenEventType) {
+    switch eventType {
+    case .add(let penPayload):
+      let stroke = PenMapper.convert(payload: penPayload)
+
+      if !strokes.contains(where: { $0.id == stroke.id }) {
+        strokes.append(stroke)
+        publishSnapshot()
+      }
+    case .replace(let penPayload):
+      let replaceTo = PenMapper.convert(payload: penPayload)
+      let targetId = replaceTo.id
+
+      strokes = strokes.map { stroke in
+        if stroke.id == targetId {
+          return replaceTo
+        }
+        return stroke
+      }
+      publishSnapshot()
+    case .delete(let id):
+      strokes.removeAll { $0.id == id }
+      persistedStrokes.removeAll { $0.id == id }
+      publishSnapshot()
+    case .reset:
+      strokes.removeAll()
+      persistedStrokes.removeAll()
+      deleteStrokes.removeAll()
+      publishSnapshot()
+    }
+  }
+
+  func sendPenCommand(command: PenNetworkCommand) {
+    let sendingEventType: PenEventType
+
+    switch command {
+    case .add(let stroke):
+      sendingEventType = .add(PenMapper.convert(stroke: stroke))
+    case .replace(let stroke):
+      sendingEventType = .replace(PenMapper.convert(stroke: stroke))
+    case .remove(let id):
+      sendingEventType = .delete(id: id)
+    case .reset:
+      sendingEventType = .reset
+    }
+
+    Task.detached { [networkService] in
+      await networkService.send(for: .penUpdated(sendingEventType))
+    }
+  }
+}
+
+// MARK: - Snapshot
+
+private extension GuidingStrokeRepository {
+  func makeSnapshot() -> StrokeSnapshot {
+    StrokeSnapshot(
+      persistedStrokes: persistedStrokes,
+      strokes: strokes,
+      deleteStrokes: deleteStrokes
+    )
+  }
+
+  func publishSnapshot() {
+    snapshotContinuation.yield(makeSnapshot())
+  }
+}

--- a/QueenCam/QueenCam/Services/Guiding/GuidingStrokeRepositoryProtocol.swift
+++ b/QueenCam/QueenCam/Services/Guiding/GuidingStrokeRepositoryProtocol.swift
@@ -1,0 +1,37 @@
+//
+//  GuidingStrokeRepositoryProtocol.swift
+//  QueenCam
+//
+//  Created by 임영택 on 6/21/26.
+//
+
+import CoreGraphics
+import Foundation
+
+struct StrokeSnapshot: Equatable {
+  let persistedStrokes: [Stroke]
+  let strokes: [Stroke]
+  let deleteStrokes: [[Stroke]]
+}
+
+struct DrawableStroke: Equatable {
+  let id: UUID
+  let points: [CGPoint]
+  let author: Role
+}
+
+protocol GuidingStrokeRepositoryProtocol: AnyObject {
+  var snapshots: AsyncStream<StrokeSnapshot> { get }
+
+  func currentSnapshot() -> StrokeSnapshot
+  func captureDrawableStrokes() -> [DrawableStroke]
+
+  @discardableResult
+  func add(initialPoints: [CGPoint], isMagicPen: Bool, author: Role) -> UUID
+  func updateStroke(id: UUID, points: [CGPoint], endDrawing: Bool, author: Role)
+  func saveStroke(for author: Role)
+  func remove(_ id: UUID, author: Role)
+  func deleteAll(for author: Role)
+  func reset()
+  func undo(for author: Role)
+}

--- a/QueenCam/QueenCamTests/Services/Camera/CameraSettingsServiceTests.swift
+++ b/QueenCam/QueenCamTests/Services/Camera/CameraSettingsServiceTests.swift
@@ -1,0 +1,23 @@
+//
+//  CameraSettingsServiceTests.swift
+//  QueenCamTests
+//
+//  Created by 임영택 on 6/21/26.
+//
+
+import Foundation
+import Testing
+
+@testable import QueenCam
+
+@Suite("CameraSettingsService Tests")
+struct CameraSettingsServiceTests {
+  @Test("펜 가이드 함께 저장 설정 기본값은 켜짐이다")
+  func saveGuidingOverlayImageDefaultIsOn() {
+    UserDefaults.standard.removeObject(forKey: "saveGuidingOverlayImageOn")
+
+    let service = CameraSettingsService()
+
+    #expect(service.saveGuidingOverlayImageOn == true)
+  }
+}

--- a/QueenCam/QueenCamTests/Services/Camera/Overlay/StrokeOverlayGeometryTests.swift
+++ b/QueenCam/QueenCamTests/Services/Camera/Overlay/StrokeOverlayGeometryTests.swift
@@ -1,0 +1,33 @@
+//
+//  StrokeOverlayGeometryTests.swift
+//  QueenCamTests
+//
+//  Created by 임영택 on 6/21/26.
+//
+
+import CoreGraphics
+import Testing
+
+@testable import QueenCam
+
+@Suite("StrokeOverlayGeometry Tests")
+struct StrokeOverlayGeometryTests {
+  @Test("3:4 캔버스를 넓은 이미지 중앙에 aspect-fit한다")
+  func aspectFitRectInWideImage() {
+    let rect = StrokeOverlayGeometry.aspectFitRect(
+      in: CGRect(x: 0, y: 0, width: 400, height: 400)
+    )
+
+    #expect(rect == CGRect(x: 50, y: 0, width: 300, height: 400))
+  }
+
+  @Test("정규화 좌표를 overlay rect 기준 절대 좌표로 변환한다")
+  func convertsNormalizedPoint() {
+    let point = StrokeOverlayGeometry.point(
+      from: CGPoint(x: 0.25, y: 0.75),
+      in: CGRect(x: 10, y: 20, width: 200, height: 400)
+    )
+
+    #expect(point == CGPoint(x: 60, y: 320))
+  }
+}

--- a/QueenCam/QueenCamTests/Services/Guiding/GuidingStrokeRepositoryTests.swift
+++ b/QueenCam/QueenCamTests/Services/Guiding/GuidingStrokeRepositoryTests.swift
@@ -1,0 +1,122 @@
+//
+//  GuidingStrokeRepositoryTests.swift
+//  QueenCamTests
+//
+//  Created by 임영택 on 6/21/26.
+//
+
+import Combine
+import Foundation
+import Testing
+import WiFiAware
+
+@testable import QueenCam
+
+private final class MockGuidingNetworkService: NetworkServiceProtocol {
+  var mode: NetworkType?
+  var networkState: NetworkState?
+  var lastStopReason: String?
+
+  private let networkEventSubject = PassthroughSubject<NetworkEvent?, Never>()
+  private(set) var sentEvents: [NetworkEvent] = []
+
+  var deviceConnectionsPublisher: AnyPublisher<[WAPairedDevice: ConnectionDetail], Never> {
+    Just([:]).eraseToAnyPublisher()
+  }
+
+  var lastErrorPublisher: AnyPublisher<Error?, Never> {
+    Just(nil).eraseToAnyPublisher()
+  }
+
+  var networkStatePublisher: AnyPublisher<NetworkState?, Never> {
+    Just(networkState).eraseToAnyPublisher()
+  }
+
+  var networkEventPublisher: AnyPublisher<NetworkEvent?, Never> {
+    networkEventSubject.eraseToAnyPublisher()
+  }
+
+  var deviceReportsPublisher: AnyPublisher<[WAPairedDevice: WAPerformanceReport], Never> {
+    Just([:]).eraseToAnyPublisher()
+  }
+
+  func run(for device: WAPairedDevice) {}
+  func reconnect(for device: WAPairedDevice) {}
+  func stop(byUser: Bool, userReason: String?) {}
+  func disconnect() {}
+
+  func send(for event: NetworkEvent) async {
+    sentEvents.append(event)
+  }
+
+  func emit(_ event: NetworkEvent) {
+    networkEventSubject.send(event)
+  }
+}
+
+@Suite("GuidingStrokeRepository Tests")
+struct GuidingStrokeRepositoryTests {
+  @Test("변경 사항을 snapshot stream과 current snapshot에 반영한다")
+  func publishesSnapshots() async throws {
+    let networkService = MockGuidingNetworkService()
+    let repository = GuidingStrokeRepository(networkService: networkService)
+    var iterator = repository.snapshots.makeAsyncIterator()
+
+    let initial = await iterator.next()
+    #expect(initial?.strokes.isEmpty == true)
+
+    let strokeId = repository.add(
+      initialPoints: [CGPoint(x: 0.1, y: 0.2), CGPoint(x: 0.3, y: 0.4)],
+      isMagicPen: false,
+      author: .photographer
+    )
+
+    let updated = await iterator.next()
+    #expect(updated?.strokes.map(\.id) == [strokeId])
+    #expect(repository.currentSnapshot().strokes.map(\.id) == [strokeId])
+  }
+
+  @Test("촬영용 stroke는 매직펜과 점이 부족한 stroke를 제외한다")
+  func captureDrawableStrokesFiltersMagicPenAndShortStroke() {
+    let networkService = MockGuidingNetworkService()
+    let repository = GuidingStrokeRepository(networkService: networkService)
+
+    let normalId = repository.add(
+      initialPoints: [CGPoint(x: 0.1, y: 0.2), CGPoint(x: 0.3, y: 0.4)],
+      isMagicPen: false,
+      author: .photographer
+    )
+    repository.add(
+      initialPoints: [CGPoint(x: 0.2, y: 0.3), CGPoint(x: 0.4, y: 0.5)],
+      isMagicPen: true,
+      author: .photographer
+    )
+    repository.add(
+      initialPoints: [CGPoint(x: 0.5, y: 0.6)],
+      isMagicPen: false,
+      author: .model
+    )
+
+    let drawableStrokes = repository.captureDrawableStrokes()
+
+    #expect(drawableStrokes.map(\.id) == [normalId])
+    #expect(drawableStrokes.first?.author == .photographer)
+  }
+
+  @Test("네트워크 pen 이벤트를 repository 상태에 반영한다")
+  func receivesNetworkPenEvents() async throws {
+    let networkService = MockGuidingNetworkService()
+    let repository = GuidingStrokeRepository(networkService: networkService)
+    let stroke = Stroke(
+      points: [CGPoint(x: 0.2, y: 0.2), CGPoint(x: 0.8, y: 0.8)],
+      isMagicPen: false,
+      author: .model,
+      endDrawing: true
+    )
+
+    networkService.emit(.penUpdated(.add(PenMapper.convert(stroke: stroke))))
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    #expect(repository.currentSnapshot().strokes == [stroke])
+  }
+}

--- a/docs/2026-06-21-pen-viewmodel-guiding-stroke-repository.md
+++ b/docs/2026-06-21-pen-viewmodel-guiding-stroke-repository.md
@@ -1,0 +1,281 @@
+# PenViewModel에서 GuidingStrokeRepository로 이동한 책임
+
+## 배경
+
+펜 오버레이를 사진 저장 시점에 합성하려면 촬영 레이어가 현재 stroke 목록을 조회할 수 있어야 한다. 기존 구조에서는 `PenViewModel`이 stroke 상태와 네트워크 동기화를 함께 소유하고 있어서 `CameraViewModel`이 `PenViewModel`에 의존해야 하는 압력이 생겼다. 이번 변경은 stroke 상태의 단일 출처를 `GuidingStrokeRepository`로 옮기고, 각 ViewModel은 필요한 인터페이스만 바라보도록 정리한 것이다.
+
+## 책임 비교
+
+| 책임 | 기존 위치 | 변경 후 위치 |
+| --- | --- | --- |
+| 현재 세션 stroke 보관 | `PenViewModel.strokes` | `GuidingStrokeRepository.strokes` |
+| 펜 툴 해제 후 유지되는 stroke 보관 | `PenViewModel.persistedStrokes` | `GuidingStrokeRepository.persistedStrokes` |
+| 전체 삭제 후 undo 대상 보관 | `PenViewModel.deleteStrokes` | `GuidingStrokeRepository.deleteStrokes` |
+| stroke 추가/수정/삭제/초기화 로직 | `PenViewModel` | `GuidingStrokeRepository` |
+| `.penUpdated` 네트워크 이벤트 수신 | `PenViewModel.bind()` | `GuidingStrokeRepository.bind()` |
+| `.penUpdated` 네트워크 이벤트 송신 | `PenViewModel.sendPenCommand(...)` | `GuidingStrokeRepository.sendPenCommand(...)` |
+| UI 표시용 stroke 상태 제공 | `PenViewModel` 내부 배열 직접 관찰 | repository `AsyncStream<StrokeSnapshot>` 구독 후 `PenViewModel`에 반영 |
+| 촬영 저장용 일반펜 stroke 조회 | 불가 또는 `PenViewModel` 의존 필요 | `GuidingStrokeRepository.captureDrawableStrokes()` |
+| 토스트, 현재 역할, 최초 드로잉 여부 | `PenViewModel` | `PenViewModel` 유지 |
+
+## 로직 이동 상세
+
+<table>
+  <thead>
+    <tr>
+      <th>로직</th>
+      <th>기존 PenViewModel 중심 구조</th>
+      <th>변경 후 Repository 중심 구조</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Stroke 추가</td>
+      <td>
+        <pre><code class="language-swift">func add(initialPoints: [CGPoint], isMagicPen: Bool) {
+  let stroke = Stroke(
+    points: initialPoints,
+    isMagicPen: isMagicPen,
+    author: currentRole
+  )
+
+  strokes.append(stroke)
+  hasEverDrawn = true
+  sendPenCommand(.add(stroke))
+}</code></pre>
+      </td>
+      <td>
+        <pre><code class="language-swift">func add(initialPoints: [CGPoint], isMagicPen: Bool) {
+  hasEverDrawn = true
+
+  repository.add(
+    initialPoints: initialPoints,
+    isMagicPen: isMagicPen,
+    author: currentRole
+  )
+}</code></pre>
+        <pre><code class="language-swift">func add(..., author: Role) -> UUID {
+  let stroke = Stroke(...)
+  strokes.append(stroke)
+  sendPenCommand(.add(stroke))
+  yieldSnapshot()
+  return stroke.id
+}</code></pre>
+      </td>
+    </tr>
+    <tr>
+      <td>Stroke 수정</td>
+      <td>
+        <pre><code class="language-swift">func updateStroke(id: UUID, points: [CGPoint], endDrawing: Bool) {
+  guard let index = strokes.firstIndex(where: { $0.id == id }),
+        strokes[index].author == currentRole else { return }
+
+  strokes[index].points = points
+  strokes[index].endDrawing = endDrawing
+  sendPenCommand(.replace(strokes[index]))
+}</code></pre>
+      </td>
+      <td>
+        <pre><code class="language-swift">func updateStroke(id: UUID, points: [CGPoint], endDrawing: Bool) {
+  repository.updateStroke(
+    id: id,
+    points: points,
+    endDrawing: endDrawing,
+    author: currentRole
+  )
+}</code></pre>
+        <pre><code class="language-swift">func updateStroke(..., author: Role) {
+  guard let index = strokes.firstIndex(where: { $0.id == id }),
+        strokes[index].author == author else { return }
+
+  strokes[index].points = points
+  strokes[index].endDrawing = endDrawing
+  sendPenCommand(.replace(strokes[index]))
+  yieldSnapshot()
+}</code></pre>
+      </td>
+    </tr>
+    <tr>
+      <td>Stroke 저장</td>
+      <td>
+        <pre><code class="language-swift">func saveStroke() {
+  let myStrokes = strokes.filter { $0.author == currentRole }
+
+  persistedStrokes.append(contentsOf: myStrokes)
+  strokes.removeAll { $0.author == currentRole }
+  deleteStrokes.removeAll { $0.author == currentRole }
+}</code></pre>
+      </td>
+      <td>
+        <pre><code class="language-swift">func saveStroke() {
+  repository.saveStroke(for: currentRole)
+}</code></pre>
+        <pre><code class="language-swift">func saveStroke(for author: Role) {
+  let myStrokes = strokes.filter { $0.author == author }
+
+  persistedStrokes.append(contentsOf: myStrokes)
+  strokes.removeAll { $0.author == author }
+  deleteStrokes.removeAll { $0.author == author }
+  yieldSnapshot()
+}</code></pre>
+      </td>
+    </tr>
+    <tr>
+      <td>전체 삭제와 undo</td>
+      <td>
+        <pre><code class="language-swift">func deleteAll() {
+  deleteStrokes = persistedStrokes + strokes
+  strokes.removeAll()
+  persistedStrokes.removeAll()
+  sendPenCommand(.deleteAll)
+}
+
+func undo() {
+  persistedStrokes = deleteStrokes
+  deleteStrokes.removeAll()
+  sendPenCommand(.undo)
+}</code></pre>
+      </td>
+      <td>
+        <pre><code class="language-swift">func deleteAll() {
+  repository.deleteAll()
+}
+
+func undo() {
+  repository.undo()
+}</code></pre>
+        <pre><code class="language-swift">func deleteAll() {
+  deleteStrokes = persistedStrokes + strokes
+  strokes.removeAll()
+  persistedStrokes.removeAll()
+  sendPenCommand(.deleteAll)
+  yieldSnapshot()
+}
+
+func undo() {
+  persistedStrokes = deleteStrokes
+  deleteStrokes.removeAll()
+  sendPenCommand(.undo)
+  yieldSnapshot()
+}</code></pre>
+      </td>
+    </tr>
+    <tr>
+      <td>네트워크 수신</td>
+      <td>
+        <pre><code class="language-swift">func bind() {
+  networkService.networkEventPublisher
+    .compactMap { event -> PenEventType? in
+      guard case .penUpdated(let payload) = event else { return nil }
+      return payload
+    }
+    .sink { [weak self] event in
+      self?.applyPenEvent(event)
+    }
+}</code></pre>
+      </td>
+      <td>
+        <pre><code class="language-swift">private func bind() {
+  networkService.networkEventPublisher
+    .compactMap { event -> PenEventType? in
+      guard case .penUpdated(let payload) = event else { return nil }
+      return payload
+    }
+    .sink { [weak self] event in
+      self?.applyPenEvent(event)
+      self?.yieldSnapshot()
+    }
+}</code></pre>
+        <pre><code class="language-swift">private func observeSnapshots() {
+  Task {
+    for await snapshot in repository.snapshots {
+      strokes = snapshot.strokes
+      persistedStrokes = snapshot.persistedStrokes
+      deleteStrokes = snapshot.deleteStrokes
+    }
+  }
+}</code></pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+표의 코드는 리뷰 이해를 위한 축약 예시다. 핵심은 `PenViewModel`이 stroke 배열과 네트워크 이벤트를 직접 조작하던 흐름을 끊고, 사용자 액션을 repository write API로 전달하는 역할만 맡도록 변경한 것이다.
+
+## 촬영 저장 관점의 변화
+
+`CameraViewModel`은 더 이상 펜 화면의 ViewModel을 몰라도 된다. 촬영 시점에는 `GuidingStrokeRepository.captureDrawableStrokes()`를 호출해 저장 가능한 stroke snapshot을 가져온다.
+
+저장 가능한 stroke의 기준은 다음과 같다.
+
+- `persistedStrokes + strokes`에 포함되어 있음
+- point가 2개 이상임
+- `isMagicPen == false`
+
+이 결과는 `DrawableStroke`로 변환되어 `CameraManager`에 전달된다. `CameraManager`는 사진 저장 직전 `PhotoOverlayCompositingService`로 원본 `PhotoOuput`을 합성 가능한 output으로 가공한다. `DrawableStroke`는 사진 합성에 필요한 id, normalized points, author만 담기 때문에 카메라 저장 로직이 펜 UI 상태에 의존하지 않는다.
+
+## 남긴 책임
+
+`PenViewModel`에는 다음 책임을 의도적으로 남겼다.
+
+- 현재 역할(`currentRole`)과 기본 역할 결정
+- 최초 드로잉 여부(`hasEverDrawn`)
+- 펜/매직펜 관련 toast 노출 상태
+- View가 사용하는 `strokes`, `persistedStrokes`, `deleteStrokes` 관찰 상태
+
+즉, `PenViewModel`은 “펜 UI 상태와 사용자 액션 전달자”이고, `GuidingStrokeRepository`는 “stroke 상태와 동기화의 단일 출처”다.
+
+## 예상되는 문제
+
+현재 카메라 설정에서는 `AVCapturePhotoOutput.isAutoDeferredPhotoDeliveryEnabled`를 켜고 있다. 이 설정이 켜져 있으면 시스템이 촬영 결과를 일반 photo data로 바로 전달하지 않고 `AVCaptureDeferredPhotoProxy`로 먼저 전달할 수 있다.
+
+일반 저장 경로는 최종 still image data를 `.photo` 리소스로 저장한다.
+
+```swift
+PhotoLibraryHelpers.saveToPhotoLibrary(photoOutput.imageData)
+```
+
+deferred 저장 경로는 `AVCaptureDeferredPhotoProxy.fileDataRepresentation()`에서 얻은 data를 `.photoProxy` 리소스로 저장한다.
+
+```swift
+PhotoLibraryHelpers.saveProxyToPhotoLibrary(photoOutput.imageData)
+```
+
+펜 오버레이 저장이 켜진 상태에서 deferred 경로를 그대로 허용하면 `CameraManager`가 저장 직전 `PhotoOverlayCompositingService`로 `PhotoOuput`을 가공한다. 이 경우 원본 proxy data가 그대로 저장되지 않고, proxy data를 `UIImage`로 읽어 오버레이를 합성한 뒤 새 JPEG로 인코딩한 결과가 `.photoProxy`로 저장된다.
+
+```swift
+let photoOutput = process(.livePhoto(
+  thumbnail: thumbnail,
+  imageData: deferredPhotoProxyData,
+  videoData: movieData
+))
+
+PhotoLibraryHelpers.saveDeferredLivePhotoToPhotosLibrary(
+  proxyData: photoOutput.imageData,
+  livePhotoMovieURL: outputFileURL
+)
+```
+
+이 경로의 리스크는 다음과 같다.
+
+- 새로 인코딩한 JPEG가 Photos에서 deferred photo proxy 리소스로 완성되는지 public API 수준에서 명확하게 검증되어 있지 않다.
+- deferred Live Photo에서 `.photoProxy + .pairedVideo` 조합이 정상 저장되더라도, 이후 시스템이 최종 고품질 사진으로 완성하는 과정에서 오버레이가 유지되는지 확인이 필요하다.
+- 현재 delegate는 일반 photo callback과 deferred proxy callback의 이중 저장을 명시적으로 guard하지 않는다. 지금까지 큰 사이드이펙트는 확인되지 않았고, 문제가 생겨도 예상되는 영향은 중복 저장이다.
+
+Bob의 셀프 QA에서 상대방 폰에는 합성된 Live Photo가 전송되지만, 촬영 폰에는 합성된 Live Photo가 잠깐 보였다가 잠시 뒤 합성되지 않은 버전으로 바뀌는 현상이 확인됐다. 이는 촬영 폰의 Photos가 `.photoProxy`를 먼저 보여준 뒤 시스템이 최종 deferred still image로 완성하면서, 오버레이가 없는 원본 결과로 대체되는 흐름으로 판단했다.
+
+이번 PR에서는 오버레이 저장 대상 stroke가 있을 때 deferred photo delivery를 끈다.
+
+```swift
+performCapturePhoto(allowsDeferredPhotoDelivery: false) { photoOutput in
+  photoOverlayCompositingService.composite(photoOutput: photoOutput, strokes: drawableStrokes)
+}
+```
+
+오버레이 stroke가 없는 촬영은 기존처럼 deferred photo delivery를 허용한다.
+
+```swift
+performCapturePhoto(allowsDeferredPhotoDelivery: true)
+```
+
+따라서 일반 촬영은 기존 deferred 최적화를 유지하고, 펜 오버레이가 실제로 합성되는 촬영만 최종 photo data 경로를 사용한다.


### PR DESCRIPTION
## 요약

가이드 펜툴로 촬영자와 상대방이 남긴 일반 펜 stroke를 사진과 Live Photo에 합성해서 저장하는 기능을 추가했습니다.

- `펜 가이드 함께 저장` 설정이 켜져 있고 저장 가능한 일반 펜 stroke가 있으면, 촬영 결과에 stroke overlay를 합성합니다.
- 촬영 기기에는 원본과 합성본을 모두 Photos에 저장합니다.
- 연결된 상대 기기에도 원본과 합성본을 모두 전송하며, 상대 기기는 기존 `.photoResult` 수신 저장 경로로 저장합니다.
- 매직펜 stroke와 점이 1개 이하인 stroke는 저장 합성 대상에서 제외합니다.
- 설정 기본값은 켜짐입니다.

## 사용자 동작

- 설정 ON + 일반 펜 stroke 있음
  - 촬영 기기 Photos: 원본 사진/Live Photo 1개, stroke 합성 사진/Live Photo 1개 저장
  - 상대 기기 Photos: 원본 사진/Live Photo 1개, stroke 합성 사진/Live Photo 1개 저장
  - 촬영 직후 미리보기 대표 이미지는 합성본 사용
- 설정 OFF 또는 합성 대상 stroke 없음
  - 기존 사진/Live Photo 저장 및 전송 흐름 유지
- 화면에는 매직펜이 보일 수 있지만, 저장 이미지에는 일반 펜 stroke만 합성

## 구현 방향

- stroke 상태는 `GuidingStrokeRepository`가 단일 출처로 관리합니다.
- `PenViewModel`은 stroke 배열과 네트워크 송수신을 직접 소유하지 않고, repository read/write API와 snapshot stream만 사용합니다.
- `CameraViewModel`은 촬영 시점에 repository에서 저장 가능한 `DrawableStroke` snapshot을 가져와 `CameraManager`에 전달합니다.
- `CameraManager`는 stroke가 있을 때만 `PhotoOverlayCompositingService`로 저장 직전 `PhotoOuput`을 합성합니다.
- `PhotoOverlayCompositingService`는 상태가 없으므로 DI 컨테이너에 등록하지 않고 `CameraManager`가 기본 구현을 직접 생성합니다.
- SwiftUI `Canvas` 렌더링과 CoreGraphics 합성은 분리하되, 선 스타일과 3:4 aspect-fit 좌표 계산은 `StrokeOverlayRendering`으로 공유합니다.

## 구조

```mermaid
flowchart LR
    NetworkService["NetworkService\n.penUpdated 송수신"]
    Repository["GuidingStrokeRepository\nStroke SSOT\nsnapshot stream\ncaptureDrawableStrokes()"]
    PenViewModel["PenViewModel\n펜 UI 상태\nread/write API 호출"]
    PenViews["PenWriteView / SingleStrokeView\n화면 렌더링"]
    CameraViewModel["CameraViewModel\n설정 확인\n촬영 시점 stroke snapshot 조회"]
    Settings["CameraSettingsService\nsaveGuidingOverlayImageOn"]
    CameraManager["CameraManager\ncapturePhoto(drawableStrokes:)\n저장 직전 output processor 구성"]
    Compositor["PhotoOverlayCompositingService\n원본 이미지 + DrawableStroke 합성\n상태 없음, CameraManager에서 직접 생성"]
    Rendering["StrokeOverlayRendering\n스타일/좌표 계산"]
    SaveFlow["PhotoLibraryHelpers / send\n원본 + 합성본 저장·전송"]

    NetworkService <--> Repository
    Repository -->|"AsyncStream<StrokeSnapshot>"| PenViewModel
    PenViewModel -->|"write API"| Repository
    PenViewModel --> PenViews
    PenViews --> Rendering

    CameraViewModel --> Settings
    CameraViewModel -->|"captureDrawableStrokes()"| Repository
    CameraViewModel -->|"토글 ON: DrawableStroke 전달\n토글 OFF: 빈 요청"| CameraManager
    CameraManager -->|"stroke 있음"| Compositor
    CameraManager -->|"stroke 없음"| SaveFlow
    Compositor --> Rendering
    Compositor --> SaveFlow
```

## 사진/Live Photo 저장 처리

- 일반 사진은 원본 image data를 보존하고, 합성본은 기존 metadata를 최대한 유지해 새 image data로 저장합니다.
- `UIImage`로 읽을 때 원본 orientation metadata가 반영되어 이미 회전된 상태로 메모리에 올라오므로, 합성본 저장 시 orientation은 `.up`으로 고정합니다.
- Live Photo는 still image data만 합성하고, paired video data는 기존 Live Photo pairing이 유지되도록 함께 전달합니다.
- 원본 Live Photo와 합성 Live Photo를 동시에 저장할 때 같은 movie URL을 재사용하면 Photos 저장 과정의 file move와 충돌하므로, 원본 저장용 movie data를 별도 임시 파일로 복제합니다.
- 오버레이 저장 대상 stroke가 있으면 deferred photo delivery를 끄고 최종 photo data 경로에서 합성합니다.

## 참고 히스토리

- 이 PR은 기존 PR #443을 닫고 새로 작성한 구현입니다.
- #443을 읽지 않아도 이 PR만으로 리뷰할 수 있도록, 기능 요구사항과 최종 구조를 본문에 다시 정리했습니다.
- #443의 UX 방향인 설정 토글은 유지하되, stroke 상태와 네트워크 동기화 책임은 `GuidingStrokeRepository`로 이동했습니다.

## 예상되는 문제

- 현재 앱은 `isAutoDeferredPhotoDeliveryEnabled`를 사용하므로 시스템 상황에 따라 deferred photo proxy 경로가 실행될 수 있습니다.
- Bob의 셀프 QA에서 상대방 폰에는 합성된 Live Photo가 전송되지만, 촬영 폰에는 합성본이 잠깐 보였다가 잠시 뒤 합성되지 않은 버전으로 바뀌는 현상이 확인됐습니다.
- 원인은 Photos가 `.photoProxy`를 먼저 보여준 뒤 시스템이 최종 deferred still image로 완성하면서 오버레이가 없는 결과로 대체하는 흐름으로 판단했습니다.
- 이번 PR에서는 오버레이 저장 대상 stroke가 있을 때 deferred photo delivery를 끄고, 최종 photo data 경로에서만 오버레이를 합성하도록 대응했습니다.
- 오버레이 stroke가 없는 촬영은 기존처럼 deferred photo delivery를 허용합니다.

## 후속 필수 작업

- [PR 코멘트](https://github.com/DeveloperAcademy-POSTECH/2025-C6-A11-QueendomJaerim/pull/444#issuecomment-4761705011)에서 정리한 deferred proxy 전송 중복 리스크는 현재 상태에서도 유효합니다.
- 오버레이 stroke가 없는 촬영은 deferred photo delivery를 허용하므로, deferred proxy 콜백에서 저화질 proxy가 먼저 상대 기기로 전송되고 이후 최종 고화질 이미지가 다시 전송될 수 있습니다.
- 이 PR은 오버레이 저장 대상 stroke가 있는 촬영에 한해 deferred를 끄는 방식으로 범위를 제한했습니다. 전체 deferred callback/send 분리는 별도 이슈로 반드시 처리해야 합니다.

## 리뷰 참고 문서

- [`docs/2026-06-21-pen-viewmodel-guiding-stroke-repository.md`](https://github.com/DeveloperAcademy-POSTECH/2025-C6-A11-QueendomJaerim/blob/feat/pen-overlay-photo-save-v2/docs/2026-06-21-pen-viewmodel-guiding-stroke-repository.md)에 `PenViewModel`에서 `GuidingStrokeRepository`로 이동한 책임과 로직 비교, deferred proxy 경로의 리스크와 대응을 정리했습니다.

## 테스트

- `xcodebuild -project QueenCam/QueenCam.xcodeproj -scheme QueenCam -destination 'generic/platform=iOS' build`
- `xcodebuild -quiet -project QueenCam/QueenCam.xcodeproj -scheme QueenCam -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test`

Closes #442

🤖 이 PR은 Codex가 작성했습니다
