### PR TITLE
feat(settings): 의견 보내기 URL을 xcconfig 기반 설정으로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ playground.xcworkspace
 # Package.resolved
 #*.xcodeproj
 *.xcconfig
+!QueenCam/Config/Shared.xcconfig
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
 # .swiftpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Changed
 
+- 의견 보내기 URL을 xcconfig에서 관리하는 새 Google Forms 주소로 변경
 - 에이전트 작업 정책을 토픽별 문서로 분리
 
 ### Deprecated

--- a/QueenCam/Config/Shared.xcconfig
+++ b/QueenCam/Config/Shared.xcconfig
@@ -1,0 +1,1 @@
+VOC_PAGE_URL = https:/$()/docs.google.com/forms/d/e/1FAIpQLSe9gVPqQ92Na0C1-GQ0JhjWw7kNSAauRZPii1iJ1Mf6lz8-zA/viewform?pli=1

--- a/QueenCam/QueenCam.xcodeproj/project.pbxproj
+++ b/QueenCam/QueenCam.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3D2DCCAA2F1A100000000001 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config/Shared.xcconfig; sourceTree = "<group>"; };
 		3D5E6BEE2E7D687300A0E03A /* QueenCam.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QueenCam.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D5E6BFB2E7D687300A0E03A /* QueenCamTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueenCamTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D5E6C052E7D687300A0E03A /* QueenCamUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueenCamUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -101,6 +102,7 @@
 			isa = PBXGroup;
 			children = (
 				3D6CDA632E8E1DF1006C445A /* .swiftlint.yml */,
+				3D2DCCAA2F1A100000000001 /* Shared.xcconfig */,
 				3D5E6BF02E7D687300A0E03A /* QueenCam */,
 				3D5E6BFE2E7D687300A0E03A /* QueenCamTests */,
 				3D5E6C082E7D687300A0E03A /* QueenCamUITests */,
@@ -455,6 +457,7 @@
 		};
 		3D5E6C102E7D687300A0E03A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D2DCCAA2F1A100000000001 /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = ZZikZZa;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -506,6 +509,7 @@
 		};
 		3D5E6C112E7D687300A0E03A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D2DCCAA2F1A100000000001 /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = ZZikZZa;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/QueenCam/QueenCam/Info.plist
+++ b/QueenCam/QueenCam/Info.plist
@@ -8,6 +8,8 @@
 	<false/>
 	<key>QueenCamCompatibleMinimumVersion</key>
 	<string>1.1.7</string>
+	<key>VOCPageURL</key>
+	<string>$(VOC_PAGE_URL)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Medium.ttf</string>

--- a/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift
@@ -16,9 +16,12 @@ struct SettingsMainView {
   @State private var isConfirmingRole = false
 
   // MARK: - URLs
-  let vocPageURL = URL(
-    string: "https://docs.google.com/forms/d/e/1FAIpQLSc0GRoJYU8a-Ki5PmEDIv7GmBRtJ0PNG-zh-YsM5i1FzCWkJg/viewform?usp=header"
-  )
+  var vocPageURL: URL? {
+    guard let urlString = Bundle.main.infoDictionary?["VOCPageURL"] as? String else {
+      return nil
+    }
+    return URL(string: urlString)
+  }
   let privacyPageURL = URL(
     string: "https://cyan-zydeco-5e9.notion.site/ZZikZZa-2025-11-13-2aa1b6b29f2c80cf90eed7ca2afc0e32?pvs=73"
   )

--- a/docs/superpowers/plans/2026-07-16-voc-page-xcconfig.md
+++ b/docs/superpowers/plans/2026-07-16-voc-page-xcconfig.md
@@ -1,0 +1,94 @@
+# VOC Page xcconfig Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 의견 보내기 URL을 xcconfig에서 관리하고 Info.plist를 거쳐 Bundle에서 읽도록 변경한다.
+
+**Architecture:** 공통 xcconfig의 `VOC_PAGE_URL`을 Debug와 Release 빌드 구성에 연결한다. Info.plist의 `VOCPageURL`이 이 값을 치환하며, 설정 화면은 Bundle에서 문자열을 읽어 URL로 변환한다.
+
+**Tech Stack:** Xcode build configuration, Info.plist, SwiftUI, Swift
+
+## Global Constraints
+
+- 새 URL은 `https://docs.google.com/forms/d/e/1FAIpQLSe9gVPqQ92Na0C1-GQ0JhjWw7kNSAauRZPii1iJ1Mf6lz8-zA/viewform?pli=1`이다.
+- Swift 코드에 VOC URL을 하드코딩하지 않는다.
+- Debug와 Release 모두 같은 URL 설정을 사용한다.
+- 모든 변경은 단일 커밋으로 만든다.
+
+---
+
+### Task 1: VOC URL 구성 연결과 화면 조회
+
+**Files:**
+- Create: `QueenCam/Config/Shared.xcconfig`
+- Modify: `QueenCam/QueenCam.xcodeproj/project.pbxproj`
+- Modify: `QueenCam/QueenCam/Info.plist`
+- Modify: `QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: Xcode build setting `VOC_PAGE_URL`
+- Produces: Info.plist 문자열 키 `VOCPageURL`, `SettingsMainView.vocPageURL: URL?`
+
+- [ ] **Step 1: 현재 설정이 없음을 확인한다**
+
+Run: `xcodebuild -project QueenCam/QueenCam.xcodeproj -scheme QueenCam -configuration Debug -showBuildSettings | rg 'VOC_PAGE_URL'`
+
+Expected: 일치 항목이 없어 종료 코드 1.
+
+- [ ] **Step 2: xcconfig와 프로젝트 연결을 추가한다**
+
+`QueenCam/Config/Shared.xcconfig`에 다음 값을 추가한다. xcconfig에서 `//`가 주석으로 해석되지 않도록 빈 빌드 설정 치환을 사용한다.
+
+```xcconfig
+VOC_PAGE_URL = https:/$()/docs.google.com/forms/d/e/1FAIpQLSe9gVPqQ92Na0C1-GQ0JhjWw7kNSAauRZPii1iJ1Mf6lz8-zA/viewform?pli=1
+```
+
+프로젝트 파일에 xcconfig 파일 참조를 추가하고 QueenCam 타깃의 Debug와 Release `XCBuildConfiguration`에 `baseConfigurationReference`로 연결한다.
+
+- [ ] **Step 3: Info.plist와 Swift 조회를 구현한다**
+
+`Info.plist`에 다음 키를 추가한다.
+
+```xml
+<key>VOCPageURL</key>
+<string>$(VOC_PAGE_URL)</string>
+```
+
+`SettingsMainView`의 VOC URL을 다음 Bundle 조회로 교체한다.
+
+```swift
+var vocPageURL: URL? {
+  guard let urlString = Bundle.main.infoDictionary?["VOCPageURL"] as? String else {
+    return nil
+  }
+  return URL(string: urlString)
+}
+```
+
+- [ ] **Step 4: CHANGELOG를 갱신한다**
+
+`CHANGELOG.md`의 `[Unreleased]` 아래 `Changed`에 의견 보내기 URL을 xcconfig 기반 새 Google Forms 주소로 변경했다는 항목을 추가한다.
+
+- [ ] **Step 5: 빌드 설정과 빌드를 검증한다**
+
+Run: `xcodebuild -project QueenCam/QueenCam.xcodeproj -scheme QueenCam -configuration Debug -showBuildSettings | rg 'VOC_PAGE_URL'`
+
+Expected: 새 Google Forms URL이 출력된다.
+
+Run: `xcodebuild -project QueenCam/QueenCam.xcodeproj -scheme QueenCam -configuration Release -showBuildSettings | rg 'VOC_PAGE_URL'`
+
+Expected: 같은 URL이 출력된다.
+
+Run: `xcodebuild -project QueenCam/QueenCam.xcodeproj -scheme QueenCam -configuration Debug -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 6: 단일 커밋을 생성한다**
+
+```bash
+git add QueenCam/Config/Shared.xcconfig QueenCam/QueenCam.xcodeproj/project.pbxproj QueenCam/QueenCam/Info.plist QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift CHANGELOG.md docs/superpowers
+git commit
+```
+
+커밋 제목은 `feat: 의견 보내기 URL을 xcconfig 기반 설정으로 변경`으로 작성하고 본문 끝에 `Co-authored-by: Codex <noreply@openai.com>`를 추가한다.

--- a/docs/superpowers/specs/2026-07-16-voc-page-xcconfig-design.md
+++ b/docs/superpowers/specs/2026-07-16-voc-page-xcconfig-design.md
@@ -1,0 +1,19 @@
+# VOC 페이지 URL 설정 설계
+
+## 목표
+
+설정 화면의 의견 보내기 URL을 새 Google Forms 주소로 변경하고, Swift 코드에 URL을 하드코딩하지 않는다.
+
+## 설계
+
+- 공통 xcconfig에 `VOC_PAGE_URL` 빌드 설정을 정의한다.
+- Debug와 Release 구성 모두 해당 xcconfig를 사용한다.
+- `Info.plist`의 `VOCPageURL` 값에 `$(VOC_PAGE_URL)`을 지정해 빌드 시 치환한다.
+- `SettingsMainView`는 `Bundle.main.infoDictionary`에서 `VOCPageURL` 문자열을 읽어 `URL`로 변환한다.
+- 값이 없거나 유효하지 않으면 기존 `openURL` 흐름이 `nil`을 받아 `QueenLogger`로 오류를 기록한다.
+
+## 검증
+
+- `xcodebuild -showBuildSettings`로 Debug와 Release 모두 새 설정값을 해석하는지 확인한다.
+- 프로젝트 빌드로 xcconfig 연결, Info.plist 치환, Swift 컴파일을 확인한다.
+- 구성 중심 변경이므로 별도 단위 테스트는 추가하지 않는다.


### PR DESCRIPTION
## 변경 사항
- 의견 보내기 Google Forms URL을 새 주소로 변경했습니다.
- 공통 xcconfig 값을 Debug/Release 구성에 연결했습니다.
- Info.plist 빌드 설정 치환을 거쳐 Bundle에서 URL을 조회하도록 변경했습니다.
- CHANGELOG의 Unreleased 항목을 갱신했습니다.

## 검증
- Debug/Release `VOC_PAGE_URL` 빌드 설정 확인
- iOS Simulator Debug 빌드 성공
- 빌드 산출물 Info.plist의 `VOCPageURL` 치환값 확인
- 기존 SwiftLint 경고 83건, 심각 오류 0건

🤖 이 PR은 Codex가 작성했습니다