### PR TITLE
refactor(config): 앱 호환 최소 버전을 xcconfig로 이동

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Changed
 
+- 앱 호환 최소 버전 값을 xcconfig에서 관리하도록 변경
 - 의견 보내기 URL을 xcconfig에서 관리하는 새 Google Forms 주소로 변경
 - 에이전트 작업 정책을 토픽별 문서로 분리
 

--- a/QueenCam/Config/Shared.xcconfig
+++ b/QueenCam/Config/Shared.xcconfig
@@ -1,1 +1,2 @@
+QUEENCAM_COMPATIBLE_MINIMUM_VERSION = 1.1.7
 VOC_PAGE_URL = https:/$()/docs.google.com/forms/d/e/1FAIpQLSe9gVPqQ92Na0C1-GQ0JhjWw7kNSAauRZPii1iJ1Mf6lz8-zA/viewform?pli=1

--- a/QueenCam/QueenCam/Info.plist
+++ b/QueenCam/QueenCam/Info.plist
@@ -7,7 +7,7 @@
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>
 	<key>QueenCamCompatibleMinimumVersion</key>
-	<string>1.1.7</string>
+	<string>$(QUEENCAM_COMPATIBLE_MINIMUM_VERSION)</string>
 	<key>VOCPageURL</key>
 	<string>$(VOC_PAGE_URL)</string>
 	<key>UIAppFonts</key>

--- a/docs/superpowers/plans/2026-07-16-compatible-minimum-version-xcconfig.md
+++ b/docs/superpowers/plans/2026-07-16-compatible-minimum-version-xcconfig.md
@@ -1,0 +1,60 @@
+# Compatible Minimum Version xcconfig Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 앱 호환 최소 버전을 Shared.xcconfig에서 관리하고 Info.plist를 통해 Bundle에 제공한다.
+
+**Architecture:** `Shared.xcconfig`가 호환 최소 버전의 원천이 된다. Info.plist는 빌드 설정을 치환하고 기존 `VersionUtils`는 변경 없이 Bundle 값을 읽는다.
+
+**Tech Stack:** Xcode build configuration, Info.plist, Swift
+
+## Global Constraints
+
+- 호환 최소 버전 값은 `1.1.7`이다.
+- 설정 이름은 `QUEENCAM_COMPATIBLE_MINIMUM_VERSION`이다.
+- Info.plist 키 `QueenCamCompatibleMinimumVersion`과 `VersionUtils`의 fallback `0.0.0`은 유지한다.
+- PR 대상 브랜치는 `develop`이다.
+
+---
+
+### Task 1: 호환 최소 버전 설정 이동
+
+**Files:**
+- Modify: `QueenCam/Config/Shared.xcconfig`
+- Modify: `QueenCam/QueenCam/Info.plist`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: Xcode build setting `QUEENCAM_COMPATIBLE_MINIMUM_VERSION`
+- Produces: Info.plist 키 `QueenCamCompatibleMinimumVersion`의 문자열 값
+
+- [ ] **Step 1: 현재 빌드 설정이 없음을 확인한다**
+
+Run: `xcodebuild -project QueenCam/QueenCam.xcodeproj -scheme QueenCam -configuration Debug -showBuildSettings | rg 'QUEENCAM_COMPATIBLE_MINIMUM_VERSION'`
+
+Expected: 일치 항목이 없어 종료 코드 1.
+
+- [ ] **Step 2: Shared.xcconfig에 값을 정의한다**
+
+```xcconfig
+QUEENCAM_COMPATIBLE_MINIMUM_VERSION = 1.1.7
+```
+
+- [ ] **Step 3: Info.plist 값을 빌드 설정 치환으로 변경한다**
+
+```xml
+<key>QueenCamCompatibleMinimumVersion</key>
+<string>$(QUEENCAM_COMPATIBLE_MINIMUM_VERSION)</string>
+```
+
+- [ ] **Step 4: CHANGELOG를 갱신한다**
+
+`CHANGELOG.md`의 `[Unreleased]` 아래 `Changed`에 호환 최소 버전을 xcconfig에서 관리하도록 변경했다는 항목을 추가한다.
+
+- [ ] **Step 5: 구성과 빌드 산출물을 검증한다**
+
+Debug와 Release에서 `xcodebuild -showBuildSettings`를 실행해 값이 `1.1.7`인지 확인한다. iOS Simulator Debug 빌드 후 앱 Info.plist의 `QueenCamCompatibleMinimumVersion`이 `1.1.7`인지 `plutil`로 확인한다.
+
+- [ ] **Step 6: 커밋하고 PR을 생성한다**
+
+변경 전체를 하나의 커밋으로 만들고 원격 브랜치에 푸시한 뒤 `develop` 대상 PR을 생성한다.

--- a/docs/superpowers/specs/2026-07-16-compatible-minimum-version-xcconfig-design.md
+++ b/docs/superpowers/specs/2026-07-16-compatible-minimum-version-xcconfig-design.md
@@ -1,0 +1,19 @@
+# 호환 최소 버전 xcconfig 설정 설계
+
+## 목표
+
+앱 호환 최소 버전 값을 Info.plist에 직접 작성하지 않고 공통 xcconfig에서 관리한다.
+
+## 설계
+
+- `Shared.xcconfig`에 `QUEENCAM_COMPATIBLE_MINIMUM_VERSION`을 정의한다.
+- `Info.plist`의 `QueenCamCompatibleMinimumVersion` 값은 해당 빌드 설정을 치환한다.
+- `VersionUtils.minimumVersionCompatibleWith`는 기존처럼 Bundle의 Info.plist 값을 읽고, 값 누락 시 `0.0.0`을 사용한다.
+- 현재 앱 버전인 `MARKETING_VERSION`과 호환 최소 버전은 서로 다른 의미이므로 별도 설정으로 유지한다.
+
+## 검증
+
+- Debug와 Release 빌드 설정에서 호환 최소 버전 값을 확인한다.
+- 빌드된 앱의 Info.plist에서 치환된 값을 확인한다.
+- iOS Simulator Debug 빌드로 프로젝트 구성을 검증한다.
+- 로직 변경이 없으므로 별도 단위 테스트는 추가하지 않는다.


### PR DESCRIPTION
## 변경 사항
- `QUEENCAM_COMPATIBLE_MINIMUM_VERSION`을 `Shared.xcconfig`에 추가했습니다.
- Info.plist의 `QueenCamCompatibleMinimumVersion` 값을 빌드 설정 치환 방식으로 변경했습니다.
- `VersionUtils`의 기존 Bundle 조회와 `0.0.0` fallback은 유지했습니다.
- CHANGELOG의 Unreleased 항목을 갱신했습니다.

## 검증
- Debug/Release 빌드 설정에서 `1.1.7` 확인
- iOS Simulator Debug 빌드 성공
- 빌드 산출물 Info.plist에서 `QueenCamCompatibleMinimumVersion = 1.1.7` 확인
- 기존 SwiftLint 경고 83건, 심각 오류 0건

🤖 이 PR은 Codex가 작성했습니다