### PR TITLE
feat(analytics): 설정 컨텍스트 및 변경 이벤트 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@
 
 ### Added
 
+- 셔터 이벤트에 이벤트 발행 시점의 주요 카메라 설정을 기록하는 Analytics 설정 컨텍스트 추가
+- 설정 페이지에서 설정 변경 시 이전 값과 변경 값을 기록하는 `settings_changed` Analytics 이벤트 추가
+
 ### Changed
+
+- 신규 설치 시 펜 가이드 함께 저장 설정의 기본값을 꺼짐으로 변경
 
 ### Deprecated
 

--- a/QueenCam/QueenCam/App/QueenCamAppDelegate.swift
+++ b/QueenCam/QueenCam/App/QueenCamAppDelegate.swift
@@ -15,6 +15,7 @@ final class QueenCamAppDelegate: NSObject, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     FirebaseApp.configure()
+    DependencyContainer.defaultContainer.bootstrap()
 
     return true
   }

--- a/QueenCam/QueenCam/Common/Dependencies/DenpencyContainer.swift
+++ b/QueenCam/QueenCam/Common/Dependencies/DenpencyContainer.swift
@@ -19,16 +19,23 @@ final class DependencyContainer {
   lazy var guidingStrokeRepository: GuidingStrokeRepositoryProtocol = GuidingStrokeRepository(
     networkService: networkService
   )
-
   lazy var previewCaptureService = PreviewCaptureService()
-
   lazy var cameraSettingServcice: CameraSettingsServiceProtocol = CameraSettingsService()
-
-  lazy var notificationService: NotificationService = NotificationService()
-
+  lazy var notificationService = NotificationService()
   lazy var onboardingSettingService: OnboardingSettingsServiceProtocol = OnboardingSettingsService()
 
-  // lazy면 NotificaitonCenter 기반 이벤트 로깅이 작동하지 않을 수 있음
-  let analyticsService: AnalyticsService = AnalyticsService()
-  let globalDeviceEventObserver: GlobalDeviceEventObserver = GlobalDeviceEventObserver()
+  private lazy var analyticsScreenContext = AnalyticsScreenContext()
+  private lazy var analyticsSettingsContext = AnalyticsSettingsContext(
+    cameraSettingsService: cameraSettingServcice
+  )
+  private lazy var analyticsService = AnalyticsService(
+    screenContext: analyticsScreenContext,
+    settingsContext: analyticsSettingsContext
+  )
+  private lazy var globalDeviceEventObserver = GlobalDeviceEventObserver()
+
+  func bootstrap() {
+    _ = analyticsService
+    _ = globalDeviceEventObserver
+  }
 }

--- a/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView+Analytics.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView+Analytics.swift
@@ -1,0 +1,27 @@
+//
+//  SettingsMainView+Analytics.swift
+//  QueenCam
+//
+//  Created by 임영택 on 7/25/26.
+//
+
+extension SettingsMainView {
+  func analyticsChanges(
+    from previousSettings: SettingsState,
+    to newSettings: SettingsState
+  ) -> [AnalyticsSettingChange] {
+    var changes: [AnalyticsSettingChange] = []
+
+    if previousSettings.saveGuidingOverlayImageOn != newSettings.saveGuidingOverlayImageOn {
+      changes.append(
+        .toggle(
+          key: .saveGuidingOverlayImage,
+          previousValue: previousSettings.saveGuidingOverlayImageOn,
+          changedValue: newSettings.saveGuidingOverlayImageOn
+        )
+      )
+    }
+
+    return changes
+  }
+}

--- a/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView+Analytics.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView+Analytics.swift
@@ -14,7 +14,7 @@ extension SettingsMainView {
 
     if previousSettings.saveGuidingOverlayImageOn != newSettings.saveGuidingOverlayImageOn {
       changes.append(
-        .toggle(
+        .makeToggleChange(
           key: .saveGuidingOverlayImage,
           previousValue: previousSettings.saveGuidingOverlayImageOn,
           changedValue: newSettings.saveGuidingOverlayImageOn

--- a/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift
@@ -71,7 +71,7 @@ extension SettingsMainView: View {
 
         HeaderSeparator()
 
-        SettingSection(title: "촬영") {
+        SettingSection(title: "실험실") {
           SettingToggleSectionItem(
             title: "펜 가이드 함께 저장",
             isOn: $settings.saveGuidingOverlayImageOn

--- a/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsMainView.swift
@@ -15,7 +15,7 @@ struct SettingsMainView {
   @State private var safariSheetItem: SafariSheetItem?
   @State private var guideSheetItem: GuideSheetItem?
   @State private var isConfirmingRole = false
-  @State private var isSaveGuidingOverlayImageOn = false
+  @State private var settings: SettingsState
 
   // MARK: - URLs
   var vocPageURL: URL? {
@@ -41,6 +41,11 @@ struct SettingsMainView {
     self.navigationRouter = navigationRouter
     self.role = role
     self.cameraSettingsService = cameraSettingsService
+    self._settings = State(
+      initialValue: SettingsState(
+        saveGuidingOverlayImageOn: cameraSettingsService.saveGuidingOverlayImageOn
+      )
+    )
   }
 }
 
@@ -67,7 +72,10 @@ extension SettingsMainView: View {
         HeaderSeparator()
 
         SettingSection(title: "촬영") {
-          SettingToggleSectionItem(title: "펜 가이드 함께 저장", isOn: $isSaveGuidingOverlayImageOn)
+          SettingToggleSectionItem(
+            title: "펜 가이드 함께 저장",
+            isOn: $settings.saveGuidingOverlayImageOn
+          )
         }
         .padding(.horizontal, 20)
 
@@ -130,16 +138,20 @@ extension SettingsMainView: View {
       }
       Button("취소", role: .cancel) {}
     }
-    .onAppear {
-      isSaveGuidingOverlayImageOn = cameraSettingsService.saveGuidingOverlayImageOn
-    }
-    .onChange(of: isSaveGuidingOverlayImageOn) { _, newValue in
-      cameraSettingsService.saveGuidingOverlayImageOn = newValue
+    .onChange(of: settings) { previousSettings, newSettings in
+      persist(newSettings)
+      analyticsChanges(from: previousSettings, to: newSettings).forEach { change in
+        AnalyticsService.sendEvent(.settingsChanged(change))
+      }
     }
   }
 }
 
 extension SettingsMainView {
+  private func persist(_ settings: SettingsState) {
+    cameraSettingsService.saveGuidingOverlayImageOn = settings.saveGuidingOverlayImageOn
+  }
+
   private struct HeaderSeparator: View {
     var body: some View {
       Rectangle()

--- a/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsState.swift
+++ b/QueenCam/QueenCam/Presentation/Views/Common/Settings/Main/SettingsState.swift
@@ -1,0 +1,10 @@
+//
+//  SettingsState.swift
+//  QueenCam
+//
+//  Created by 임영택 on 7/25/26.
+//
+
+struct SettingsState: Equatable {
+  var saveGuidingOverlayImageOn: Bool
+}

--- a/QueenCam/QueenCam/Services/Analytics/AnalyticsService.swift
+++ b/QueenCam/QueenCam/Services/Analytics/AnalyticsService.swift
@@ -9,11 +9,16 @@ import FirebaseAnalytics
 
 final class AnalyticsService {
   private let screenContext: AnalyticsScreenContext
+  private let settingsContext: AnalyticsSettingsContext
 
   private let logger = QueenLogger(category: "AnalyticsService")
 
-  init(initialScreenStack: [AnalyticsScreenData] = []) {
-    self.screenContext = AnalyticsScreenContext(screenStack: initialScreenStack)
+  init(
+    screenContext: AnalyticsScreenContext,
+    settingsContext: AnalyticsSettingsContext
+  ) {
+    self.screenContext = screenContext
+    self.settingsContext = settingsContext
     self.screenContext.delegate = self
 
     NotificationCenter.default.addObserver(
@@ -66,13 +71,25 @@ final class AnalyticsService {
     logger.debug("will send event: \(event.eventName) to FirebaseAnalytics")
     Analytics.logEvent(
       event.eventName,
-      parameters: [
-        AnalyticsParameterItemName: event.eventName,
-        AnalyticsParameterContentType: event.eventType,
-        AnalyticsParameterScreenName: screenContext.getLastScreen()?.screen.displayName ?? "unknown",
-        AnalyticsParameterScreenClass: screenContext.getLastScreen()?.className ?? "unknown"
-      ]
+      parameters: parameters(for: event)
     )
+  }
+
+  func parameters(for event: AnalyticsEvent) -> [String: Any] {
+    var parameters: [String: Any] = [
+      AnalyticsParameterItemName: event.eventName,
+      AnalyticsParameterContentType: event.eventType,
+      AnalyticsParameterScreenName: screenContext.getLastScreen()?.screen.displayName ?? "unknown",
+      AnalyticsParameterScreenClass: screenContext.getLastScreen()?.className ?? "unknown"
+    ]
+
+    parameters.merge(event.parameters) { _, newValue in newValue }
+
+    if event.includesSettingsContext {
+      parameters.merge(settingsContext.snapshot().parameters) { _, newValue in newValue }
+    }
+
+    return parameters
   }
 }
 

--- a/QueenCam/QueenCam/Services/Analytics/AnalyticsSettingsContext.swift
+++ b/QueenCam/QueenCam/Services/Analytics/AnalyticsSettingsContext.swift
@@ -1,0 +1,57 @@
+//
+//  AnalyticsSettingsContext.swift
+//  QueenCam
+//
+//  Created by 임영택 on 7/25/26.
+//
+
+import Foundation
+
+/// GA 이벤트와 함께 기록할 현재 앱 설정을 제공하는 객체
+final class AnalyticsSettingsContext {
+  private let cameraSettingsService: CameraSettingsServiceProtocol
+
+  init(cameraSettingsService: CameraSettingsServiceProtocol) {
+    self.cameraSettingsService = cameraSettingsService
+  }
+
+  func snapshot() -> AnalyticsSettingsSnapshot {
+    AnalyticsSettingsSnapshot(
+      livePhotoOn: cameraSettingsService.livePhotoOn,
+      gridOn: cameraSettingsService.gridOn,
+      flashMode: cameraSettingsService.flashMode,
+      saveGuidingOverlayImageOn: cameraSettingsService.saveGuidingOverlayImageOn
+    )
+  }
+}
+
+struct AnalyticsSettingsSnapshot {
+  let livePhotoOn: Bool
+  let gridOn: Bool
+  let flashMode: FlashMode
+  let saveGuidingOverlayImageOn: Bool
+
+  var parameters: [String: Any] {
+    [
+      "settings_live_photo": toggleParameter(livePhotoOn),
+      "settings_grid": toggleParameter(gridOn),
+      "settings_flash_mode": flashModeParameter,
+      "settings_save_guiding_overlay_image": toggleParameter(saveGuidingOverlayImageOn)
+    ]
+  }
+
+  private func toggleParameter(_ isOn: Bool) -> String {
+    isOn ? "on" : "off"
+  }
+
+  private var flashModeParameter: String {
+    switch flashMode {
+    case .off:
+      return "off"
+    case .on:
+      return "on"
+    case .auto:
+      return "auto"
+    }
+  }
+}

--- a/QueenCam/QueenCam/Services/Analytics/Entities/AnalyticsEvent.swift
+++ b/QueenCam/QueenCam/Services/Analytics/Entities/AnalyticsEvent.swift
@@ -13,6 +13,7 @@ enum AnalyticsEvent {
   case shutterPressed
   case takeScreenshot
   case takeVideoCapture
+  case settingsChanged(AnalyticsSettingChange)
 
   var eventName: String {
     switch self {
@@ -21,6 +22,7 @@ enum AnalyticsEvent {
     case .shutterPressed: return "shutter_pressed"
     case .takeScreenshot: return "take_screenshot"
     case .takeVideoCapture: return "take_video_capture"
+    case .settingsChanged: return "settings_changed"
     }
   }
 
@@ -31,6 +33,49 @@ enum AnalyticsEvent {
     case .shutterPressed: return "camera"
     case .takeScreenshot: return "device"
     case .takeVideoCapture: return "device"
+    case .settingsChanged: return "settings"
     }
+  }
+
+  var includesSettingsContext: Bool {
+    switch self {
+    case .shutterPressed: return true
+    default: return false
+    }
+  }
+
+  var parameters: [String: Any] {
+    switch self {
+    case .settingsChanged(let change):
+      return [
+        "changed_key": change.key.rawValue,
+        "previous_value": change.previousValue,
+        "changed_value": change.changedValue
+      ]
+    default:
+      return [:]
+    }
+  }
+}
+
+enum AnalyticsSettingKey: String {
+  case saveGuidingOverlayImage = "save_guiding_overlay_image"
+}
+
+struct AnalyticsSettingChange {
+  let key: AnalyticsSettingKey
+  let previousValue: String
+  let changedValue: String
+
+  static func toggle(
+    key: AnalyticsSettingKey,
+    previousValue: Bool,
+    changedValue: Bool
+  ) -> AnalyticsSettingChange {
+    AnalyticsSettingChange(
+      key: key,
+      previousValue: previousValue ? "on" : "off",
+      changedValue: changedValue ? "on" : "off"
+    )
   }
 }

--- a/QueenCam/QueenCam/Services/Analytics/Entities/AnalyticsEvent.swift
+++ b/QueenCam/QueenCam/Services/Analytics/Entities/AnalyticsEvent.swift
@@ -67,11 +67,11 @@ struct AnalyticsSettingChange {
   let previousValue: String
   let changedValue: String
 
-  static func toggle(
+  static func makeToggleChange(
     key: AnalyticsSettingKey,
     previousValue: Bool,
     changedValue: Bool
-  ) -> AnalyticsSettingChange {
+  ) -> Self {
     AnalyticsSettingChange(
       key: key,
       previousValue: previousValue ? "on" : "off",

--- a/QueenCam/QueenCam/Services/Camera/CameraSettingsService.swift
+++ b/QueenCam/QueenCam/Services/Camera/CameraSettingsService.swift
@@ -11,7 +11,7 @@ final class CameraSettingsService: CameraSettingsServiceProtocol {
       livePhotoKey: false,
       gridKey: false,
       flashKey: FlashMode.off.rawValue,
-      saveGuidingOverlayImageKey: true
+      saveGuidingOverlayImageKey: false
     ])
   }
 

--- a/QueenCam/QueenCamTests/Services/Analytics/AnalyticsEventTests.swift
+++ b/QueenCam/QueenCamTests/Services/Analytics/AnalyticsEventTests.swift
@@ -35,7 +35,7 @@ struct AnalyticsEventTests {
 
   @Test("설정 변경 이벤트가 문자열 변경 페이로드를 제공한다")
   func settingsChangedProvidesStringPayload() {
-    let change = AnalyticsSettingChange.toggle(
+    let change = AnalyticsSettingChange.makeToggleChange(
       key: .saveGuidingOverlayImage,
       previousValue: false,
       changedValue: true

--- a/QueenCam/QueenCamTests/Services/Analytics/AnalyticsEventTests.swift
+++ b/QueenCam/QueenCamTests/Services/Analytics/AnalyticsEventTests.swift
@@ -1,0 +1,51 @@
+//
+//  AnalyticsEventTests.swift
+//  QueenCamTests
+//
+//  Created by 임영택 on 7/25/26.
+//
+
+import Testing
+
+@testable import QueenCam
+
+@Suite("AnalyticsEvent Tests")
+struct AnalyticsEventTests {
+  @Test("셔터 이벤트만 설정 컨텍스트를 포함한다")
+  func onlyShutterPressedIncludesSettingsContext() {
+    #expect(AnalyticsEvent.shutterPressed.includesSettingsContext)
+
+    let change = AnalyticsSettingChange(
+      key: .saveGuidingOverlayImage,
+      previousValue: "off",
+      changedValue: "on"
+    )
+    let eventsWithoutSettingsContext: [AnalyticsEvent] = [
+      .sessionStart,
+      .connectionLost,
+      .takeScreenshot,
+      .takeVideoCapture,
+      .settingsChanged(change)
+    ]
+
+    for event in eventsWithoutSettingsContext {
+      #expect(event.includesSettingsContext == false)
+    }
+  }
+
+  @Test("설정 변경 이벤트가 문자열 변경 페이로드를 제공한다")
+  func settingsChangedProvidesStringPayload() {
+    let change = AnalyticsSettingChange.toggle(
+      key: .saveGuidingOverlayImage,
+      previousValue: false,
+      changedValue: true
+    )
+    let event = AnalyticsEvent.settingsChanged(change)
+
+    #expect(event.eventName == "settings_changed")
+    #expect(event.eventType == "settings")
+    #expect(event.parameters["changed_key"] as? String == "save_guiding_overlay_image")
+    #expect(event.parameters["previous_value"] as? String == "off")
+    #expect(event.parameters["changed_value"] as? String == "on")
+  }
+}

--- a/QueenCam/QueenCamTests/Services/Analytics/AnalyticsServiceTests.swift
+++ b/QueenCam/QueenCamTests/Services/Analytics/AnalyticsServiceTests.swift
@@ -67,7 +67,7 @@ struct AnalyticsServiceTests {
       screenContext: AnalyticsScreenContext(),
       settingsContext: AnalyticsSettingsContext(cameraSettingsService: settingsService)
     )
-    let change = AnalyticsSettingChange.toggle(
+    let change = AnalyticsSettingChange.makeToggleChange(
       key: .saveGuidingOverlayImage,
       previousValue: false,
       changedValue: true

--- a/QueenCam/QueenCamTests/Services/Analytics/AnalyticsServiceTests.swift
+++ b/QueenCam/QueenCamTests/Services/Analytics/AnalyticsServiceTests.swift
@@ -1,0 +1,102 @@
+//
+//  AnalyticsServiceTests.swift
+//  QueenCamTests
+//
+//  Created by 임영택 on 7/25/26.
+//
+
+import Testing
+
+@testable import QueenCam
+
+@Suite("AnalyticsService Tests")
+struct AnalyticsServiceTests {
+  @Test("셔터 이벤트 파라미터에 현재 설정을 포함한다")
+  func shutterPressedParametersIncludeCurrentSettings() throws {
+    let settingsService = AnalyticsCameraSettingsServiceStub(
+      livePhotoOn: true,
+      gridOn: false,
+      flashMode: .on,
+      saveGuidingOverlayImageOn: true
+    )
+    let context = AnalyticsSettingsContext(cameraSettingsService: settingsService)
+    let service = AnalyticsService(
+      screenContext: AnalyticsScreenContext(),
+      settingsContext: context
+    )
+
+    let parameters = service.parameters(for: .shutterPressed)
+
+    #expect(try #require(parameters["settings_live_photo"] as? String) == "on")
+    #expect(try #require(parameters["settings_grid"] as? String) == "off")
+    #expect(try #require(parameters["settings_flash_mode"] as? String) == "on")
+    #expect(try #require(parameters["settings_save_guiding_overlay_image"] as? String) == "on")
+  }
+
+  @Test("설정 컨텍스트를 사용하지 않는 이벤트에는 설정 파라미터가 없다")
+  func sessionStartParametersExcludeSettings() {
+    let settingsService = AnalyticsCameraSettingsServiceStub(
+      livePhotoOn: true,
+      gridOn: true,
+      flashMode: .auto,
+      saveGuidingOverlayImageOn: true
+    )
+    let context = AnalyticsSettingsContext(cameraSettingsService: settingsService)
+    let service = AnalyticsService(
+      screenContext: AnalyticsScreenContext(),
+      settingsContext: context
+    )
+
+    let parameters = service.parameters(for: .sessionStart)
+
+    #expect(parameters["settings_live_photo"] == nil)
+    #expect(parameters["settings_grid"] == nil)
+    #expect(parameters["settings_flash_mode"] == nil)
+    #expect(parameters["settings_save_guiding_overlay_image"] == nil)
+  }
+
+  @Test("설정 변경 이벤트 파라미터를 최종 페이로드에 포함한다")
+  func settingsChangedParametersIncludeChange() {
+    let settingsService = AnalyticsCameraSettingsServiceStub(
+      livePhotoOn: true,
+      gridOn: true,
+      flashMode: .auto,
+      saveGuidingOverlayImageOn: false
+    )
+    let service = AnalyticsService(
+      screenContext: AnalyticsScreenContext(),
+      settingsContext: AnalyticsSettingsContext(cameraSettingsService: settingsService)
+    )
+    let change = AnalyticsSettingChange.toggle(
+      key: .saveGuidingOverlayImage,
+      previousValue: false,
+      changedValue: true
+    )
+
+    let parameters = service.parameters(for: .settingsChanged(change))
+
+    #expect(parameters["changed_key"] as? String == "save_guiding_overlay_image")
+    #expect(parameters["previous_value"] as? String == "off")
+    #expect(parameters["changed_value"] as? String == "on")
+    #expect(parameters["settings_save_guiding_overlay_image"] == nil)
+  }
+}
+
+private final class AnalyticsCameraSettingsServiceStub: CameraSettingsServiceProtocol {
+  var livePhotoOn: Bool
+  var gridOn: Bool
+  var flashMode: FlashMode
+  var saveGuidingOverlayImageOn: Bool
+
+  init(
+    livePhotoOn: Bool,
+    gridOn: Bool,
+    flashMode: FlashMode,
+    saveGuidingOverlayImageOn: Bool
+  ) {
+    self.livePhotoOn = livePhotoOn
+    self.gridOn = gridOn
+    self.flashMode = flashMode
+    self.saveGuidingOverlayImageOn = saveGuidingOverlayImageOn
+  }
+}

--- a/QueenCam/QueenCamTests/Services/Analytics/AnalyticsSettingsContextTests.swift
+++ b/QueenCam/QueenCamTests/Services/Analytics/AnalyticsSettingsContextTests.swift
@@ -1,0 +1,59 @@
+//
+//  AnalyticsSettingsContextTests.swift
+//  QueenCamTests
+//
+//  Created by 임영택 on 7/25/26.
+//
+
+import Testing
+
+@testable import QueenCam
+
+@Suite("AnalyticsSettingsContext Tests")
+struct AnalyticsSettingsContextTests {
+  @Test("이벤트 시점의 현재 카메라 설정을 스냅샷한다")
+  func snapshotReflectsCurrentCameraSettings() {
+    let settingsService = CameraSettingsServiceStub(
+      livePhotoOn: false,
+      gridOn: true,
+      flashMode: .off,
+      saveGuidingOverlayImageOn: false
+    )
+    let context = AnalyticsSettingsContext(cameraSettingsService: settingsService)
+
+    settingsService.livePhotoOn = true
+    settingsService.gridOn = false
+    settingsService.flashMode = .auto
+    settingsService.saveGuidingOverlayImageOn = true
+
+    let snapshot = context.snapshot()
+
+    #expect(snapshot.livePhotoOn == true)
+    #expect(snapshot.gridOn == false)
+    #expect(snapshot.flashMode == .auto)
+    #expect(snapshot.saveGuidingOverlayImageOn == true)
+    #expect(snapshot.parameters["settings_live_photo"] as? String == "on")
+    #expect(snapshot.parameters["settings_grid"] as? String == "off")
+    #expect(snapshot.parameters["settings_flash_mode"] as? String == "auto")
+    #expect(snapshot.parameters["settings_save_guiding_overlay_image"] as? String == "on")
+  }
+}
+
+private final class CameraSettingsServiceStub: CameraSettingsServiceProtocol {
+  var livePhotoOn: Bool
+  var gridOn: Bool
+  var flashMode: FlashMode
+  var saveGuidingOverlayImageOn: Bool
+
+  init(
+    livePhotoOn: Bool,
+    gridOn: Bool,
+    flashMode: FlashMode,
+    saveGuidingOverlayImageOn: Bool
+  ) {
+    self.livePhotoOn = livePhotoOn
+    self.gridOn = gridOn
+    self.flashMode = flashMode
+    self.saveGuidingOverlayImageOn = saveGuidingOverlayImageOn
+  }
+}

--- a/QueenCam/QueenCamTests/Services/Camera/CameraSettingsServiceTests.swift
+++ b/QueenCam/QueenCamTests/Services/Camera/CameraSettingsServiceTests.swift
@@ -12,12 +12,12 @@ import Testing
 
 @Suite("CameraSettingsService Tests")
 struct CameraSettingsServiceTests {
-  @Test("펜 가이드 함께 저장 설정 기본값은 켜짐이다")
-  func saveGuidingOverlayImageDefaultIsOn() {
+  @Test("펜 가이드 함께 저장 설정 기본값은 꺼짐이다")
+  func saveGuidingOverlayImageDefaultIsOff() {
     UserDefaults.standard.removeObject(forKey: "saveGuidingOverlayImageOn")
 
     let service = CameraSettingsService()
 
-    #expect(service.saveGuidingOverlayImageOn == true)
+    #expect(service.saveGuidingOverlayImageOn == false)
   }
 }


### PR DESCRIPTION
## 📝 개요

GA 이벤트에 발행 시점의 주요 카메라 설정을 선택적으로 포함하고, 설정 페이지에서 변경된 설정의 이전 값과 현재 값을 `settings_changed` 이벤트로 기록합니다.

신규 설치 시 `펜 가이드 함께 저장`의 기본값은 꺼짐입니다.

## 💡 변경 내용

- `AnalyticsSettingsContext`가 이벤트 발행 시점의 카메라 설정 스냅샷을 제공합니다.
- 이벤트 정의부의 `includesSettingsContext` 정책으로 설정 컨텍스트 포함 여부를 중앙 관리하며, 현재는 `shutter_pressed`만 포함합니다.
- 설정 화면의 UI 값을 순수 `SettingsState` 구조체로 통합하고 단일 `onChange`에서 이전·현재 전체 상태를 비교합니다.
- 변경된 설정마다 `settings_changed` 이벤트와 `changed_key`, `previous_value`, `changed_value` 문자열 파라미터를 전송합니다.
- Analytics 관련 의존성은 Firebase 구성 이후 `bootstrap()`에서 지연 생성합니다.
- Superpowers 설계·계획 산출물은 커밋에 포함하지 않았습니다.

## 🧱 커밋 구조

1. `6df8e23` 신규 설치 기본값과 회귀 테스트
2. `e7af1b4` Analytics 설정 컨텍스트·이벤트 정책·DI bootstrap 및 단위 테스트
3. `ed7feaf` 순수 설정 UI 상태·전체 상태 diff 이벤트 발행
4. `d607a3d` 설정 변경 팩토리 메서드 네이밍 명확화

## ✅ 자동 검증

- [x] `xcodebuild test -project QueenCam/QueenCam.xcodeproj -scheme QueenCam -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing:QueenCamTests`
- [x] QueenCamTests 20개 통과
- [x] 관련 Analytics 집중 테스트 통과
- [x] `CHANGELOG.md`의 `[Unreleased]` 갱신
- [x] 원격 `develop` 기준 뒤처진 커밋 없음

## 🎯 인수 조건

### 신규 설치 기본값

- [ ] 앱 데이터를 삭제하거나 신규 설치한 뒤 설정 페이지에 진입하면 `펜 가이드 함께 저장`이 꺼짐이다.

### Firebase Analytics 실제 전송

아래 항목은 앱 실행 Scheme의 Arguments Passed On Launch에 `-FIRDebugEnabled`를 추가하고, 네트워크가 연결된 테스트 기기/시뮬레이터를 Firebase Console의 Analytics DebugView에서 선택해 확인한다.

- [ ] 설정 페이지 진입만으로는 `settings_changed` 이벤트가 발생하지 않는다.
- [ ] `펜 가이드 함께 저장`을 `off → on`으로 변경하면 `settings_changed` 이벤트가 정확히 1건 발생한다.
- [ ] 위 이벤트의 파라미터가 모두 문자열이며 `changed_key=save_guiding_overlay_image`, `previous_value=off`, `changed_value=on`이다.
- [ ] 같은 설정을 `on → off`로 변경하면 `settings_changed` 이벤트가 정확히 1건 발생하고 `previous_value=on`, `changed_value=off`이다.
- [ ] 설정 페이지 밖에서 동일한 설정 값이 변경되는 경우에는 `settings_changed` 이벤트가 발생하지 않는다.
- [ ] 셔터를 누르면 `shutter_pressed` 이벤트에 발행 시점의 `settings_live_photo`, `settings_grid`, `settings_flash_mode`, `settings_save_guiding_overlay_image`가 문자열로 포함된다.
- [ ] 펜 가이드 저장 설정을 바꾼 뒤 다시 셔터를 누르면 `settings_save_guiding_overlay_image`가 현재 값인 `on` 또는 `off`로 반영된다.
- [ ] `session_start`, `connection_lost`, `take_screenshot`, `take_video_capture`, `settings_changed`에는 `settings_*` 카메라 설정 컨텍스트 파라미터가 포함되지 않는다.

## 💬 리뷰어 전달 사항

- `AnalyticsService`는 공통·이벤트·설정 컨텍스트 파라미터 병합과 Firebase 전송만 담당합니다.
- `SettingsState`는 UI 값과 `Equatable` 합성만 가진 순수 값 객체이며 Services/Analytics 타입을 참조하지 않습니다.
- 서비스 초기값 복사·저장과 Analytics 변경 생성은 `SettingsMainView`의 조정 영역에 있고, 설정이 늘어나도 `onChange`는 하나만 유지됩니다.
- 설정 변경 diff 변환은 `SettingsMainView+Analytics.swift`로 분리했습니다.
- 설정 컨텍스트 직렬화는 `AnalyticsSettingsSnapshot.parameters`, 이벤트 전용 직렬화는 `AnalyticsEvent.parameters`에 있습니다.
- Firebase DebugView 수동 검증이 끝난 뒤 인수 조건 체크박스를 갱신해주세요.

🤖 이 PR은 Codex (GPT-5)가 작성했습니다
